### PR TITLE
Add upstream_response_time to nginx access logs

### DIFF
--- a/ansible/roles/nginx/templates/nginx-ssl.conf
+++ b/ansible/roles/nginx/templates/nginx-ssl.conf
@@ -15,7 +15,8 @@ http {
     client_max_body_size {{ nginx_client_max_body_size }};
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$upstream_response_time';
 
     access_log  /var/log/nginx/access.log  main;
 
@@ -90,6 +91,6 @@ http {
         }
 
         error_log "{{ nginx_app_error_log }}";
-        access_log "{{ nginx_app_access_log }}";
+        access_log "{{ nginx_app_access_log }}"  main;
     }
 }

--- a/ansible/roles/nginx/templates/nginx.conf
+++ b/ansible/roles/nginx/templates/nginx.conf
@@ -15,7 +15,8 @@ http {
     client_max_body_size {{ nginx_client_max_body_size }};
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$upstream_response_time';
 
     access_log  /var/log/nginx/access.log  main;
 
@@ -62,6 +63,6 @@ http {
         }
 
         error_log "{{ nginx_app_error_log }}";
-        access_log "{{ nginx_app_access_log }}";
+        access_log "{{ nginx_app_access_log }}"  main;
     }
 }


### PR DESCRIPTION
This will allow to create detailed metric for repman app in monitoring tools (like CloudWatch)