### PR TITLE
Stop propagation of expired token exception

### DIFF
--- a/config/packages/prod/sentry.yaml
+++ b/config/packages/prod/sentry.yaml
@@ -1,6 +1,7 @@
 sentry:
     dsn: '%env(SENTRY_DSN)%'
     options:
+        send_default_pii: true
         excluded_exceptions:
             - 'Symfony\Component\Security\Core\Exception\AccessDeniedException'
             - 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException'

--- a/config/packages/prod/sentry.yaml
+++ b/config/packages/prod/sentry.yaml
@@ -1,7 +1,6 @@
 sentry:
     dsn: '%env(SENTRY_DSN)%'
     options:
-        send_default_pii: true
         excluded_exceptions:
             - 'Symfony\Component\Security\Core\Exception\AccessDeniedException'
             - 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException'

--- a/src/Service/Symfony/RefreshOAuthTokenListener.php
+++ b/src/Service/Symfony/RefreshOAuthTokenListener.php
@@ -38,15 +38,16 @@ final class RefreshOAuthTokenListener implements EventSubscriberInterface
         }
 
         $event->setResponse(new RedirectResponse($this->router->generate('refresh_oauth_token', ['type' => $exception->type()])));
+        $event->stopPropagation();
     }
 
     /**
      * @codeCoverageIgnore
      *
-     * @return array<string,string>
+     * @return array<string,array<int,string|int>>
      */
     public static function getSubscribedEvents(): array
     {
-        return [KernelEvents::EXCEPTION => 'onKernelException'];
+        return [KernelEvents::EXCEPTION => ['onKernelException', 4056]];
     }
 }


### PR DESCRIPTION
this prevents the caught exception from being sent to the sentry