### PR TITLE
Lowercase email during User initialization

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -93,7 +93,7 @@ class User implements UserInterface
     public function __construct(UuidInterface $id, string $email, string $emailConfirmToken, array $roles)
     {
         $this->id = $id;
-        $this->email = $email;
+        $this->email = \mb_strtolower($email);
         $this->emailConfirmToken = $emailConfirmToken;
         $this->roles = array_values(array_unique($roles));
         $this->createdAt = new \DateTimeImmutable();

--- a/src/Validator/UniqueEmailValidator.php
+++ b/src/Validator/UniqueEmailValidator.php
@@ -27,6 +27,8 @@ class UniqueEmailValidator extends ConstraintValidator
             return;
         }
 
+        $value = \mb_strtolower($value);
+
         if (!$this->usersQuery->getByEmail($value)->isEmpty()) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $value)

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -71,4 +71,11 @@ final class UserTest extends TestCase
     {
         self::assertTrue(Option::none()->equals($this->user->firstOrganizationAlias()));
     }
+
+    public function testEmailLowercase(): void
+    {
+        $user = new User(Uuid::uuid4(), 'tEsT@buDDy.woRKs', '4f6a2491-244a-4aef-8ec9-8dc36f7a10ce', ['ROLE_USER']);
+
+        self::assertEquals($user->getEmail(), 'test@buddy.works');
+    }
 }

--- a/tests/Unit/Validator/UniqueEmailValidatorTest.php
+++ b/tests/Unit/Validator/UniqueEmailValidatorTest.php
@@ -59,6 +59,7 @@ final class UniqueEmailValidatorTest extends ConstraintValidatorTestCase
         $this->userQueryMock
             ->expects(self::once())
             ->method('getByEmail')
+            ->with('test@buddy.works')
             ->willReturn(Option::some(new User('55fe42eb-d527-4a64-bd48-fb3f54372673', 'test@buddy.works', 'enabled', [])));
 
         $this->validator->validate('test@BUDDY.works', new UniqueEmail());

--- a/tests/Unit/Validator/UniqueEmailValidatorTest.php
+++ b/tests/Unit/Validator/UniqueEmailValidatorTest.php
@@ -53,4 +53,18 @@ final class UniqueEmailValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ value }}', 'test@buddy.works')
             ->assertRaised();
     }
+
+    public function testEmailLowerCasedViolation(): void
+    {
+        $this->userQueryMock
+            ->expects(self::once())
+            ->method('getByEmail')
+            ->willReturn(Option::some(new User('55fe42eb-d527-4a64-bd48-fb3f54372673', 'test@buddy.works', 'enabled', [])));
+
+        $this->validator->validate('test@BUDDY.works', new UniqueEmail());
+
+        $this->buildViolation('Email "{{ value }}" already exists.')
+            ->setParameter('{{ value }}', 'test@buddy.works')
+            ->assertRaised();
+    }
 }


### PR DESCRIPTION
Since emails are case insensitive, they should be lowercased.
Currently multiple accounts can be created using one, single email.