### PR TITLE
Add autorestart flag to consumer configuration

### DIFF
--- a/ansible/roles/supervisor/templates/message-consumer.conf
+++ b/ansible/roles/supervisor/templates/message-consumer.conf
@@ -4,5 +4,6 @@ command = php bin/console messenger:consume async --limit=100
 process_name = %(program_name)s_%(process_num)02d
 numprocs = {{ app_message_consumers_number }}
 autostart = true
+autorestart = true
 user = {{ system_user }}
 environment=HOME="/home/{{ system_user }}",USER="{{ system_user }}"


### PR DESCRIPTION
By default `autorestart` is `unexpected`, which means: the process will be restarted when the program exits with an exit code that is not expected. So if consumer will exit with 0 (normal) then will be not restarted :man_facepalming:. This PR will fix this. 

I apologize to all those affected, I take this blame on myself.

Ref: http://supervisord.org/configuration.html