### PR TITLE
Handle package not found exception on app level

### DIFF
--- a/src/Controller/Organization/MembersController.php
+++ b/src/Controller/Organization/MembersController.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 final class MembersController extends AbstractController
 {
@@ -59,7 +58,8 @@ final class MembersController extends AbstractController
         if ($organization->isEmpty()) {
             $this->addFlash('danger', 'Invitation not found or belongs to different user');
             $this->tokenStorage->setToken();
-            throw new AuthenticationException();
+
+            return $this->redirectToRoute('app_login');
         }
 
         $this->dispatchMessage(new AcceptInvitation($token, $user->id()->toString()));

--- a/src/MessageHandler/Organization/Package/AddBitbucketHookHandler.php
+++ b/src/MessageHandler/Organization/Package/AddBitbucketHookHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Buddy\Repman\MessageHandler\Organization\Package;
 
+use Buddy\Repman\Entity\Organization\Package;
 use Buddy\Repman\Entity\Organization\Package\Metadata;
 use Buddy\Repman\Message\Organization\Package\AddBitbucketHook;
 use Buddy\Repman\Repository\PackageRepository;
@@ -27,7 +28,11 @@ final class AddBitbucketHookHandler implements MessageHandlerInterface
 
     public function __invoke(AddBitbucketHook $message): void
     {
-        $package = $this->packages->getById(Uuid::fromString($message->packageId()));
+        $package = $this->packages->find(Uuid::fromString($message->packageId()));
+        if (!$package instanceof Package) {
+            return;
+        }
+
         $this->api->addHook(
             $package->oauthToken(),
             $package->metadata(Metadata::BITBUCKET_REPO_NAME),

--- a/src/MessageHandler/Organization/Package/AddGitHubHookHandler.php
+++ b/src/MessageHandler/Organization/Package/AddGitHubHookHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Buddy\Repman\MessageHandler\Organization\Package;
 
+use Buddy\Repman\Entity\Organization\Package;
 use Buddy\Repman\Entity\Organization\Package\Metadata;
 use Buddy\Repman\Message\Organization\Package\AddGitHubHook;
 use Buddy\Repman\Repository\PackageRepository;
@@ -27,7 +28,10 @@ final class AddGitHubHookHandler implements MessageHandlerInterface
 
     public function __invoke(AddGitHubHook $message): void
     {
-        $package = $this->packages->getById(Uuid::fromString($message->packageId()));
+        $package = $this->packages->find(Uuid::fromString($message->packageId()));
+        if (!$package instanceof Package) {
+            return;
+        }
 
         $this->api->addHook(
             $package->oauthToken(),

--- a/src/MessageHandler/Organization/Package/AddGitLabHookHandler.php
+++ b/src/MessageHandler/Organization/Package/AddGitLabHookHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Buddy\Repman\MessageHandler\Organization\Package;
 
+use Buddy\Repman\Entity\Organization\Package;
 use Buddy\Repman\Entity\Organization\Package\Metadata;
 use Buddy\Repman\Message\Organization\Package\AddGitLabHook;
 use Buddy\Repman\Repository\PackageRepository;
@@ -27,7 +28,11 @@ final class AddGitLabHookHandler implements MessageHandlerInterface
 
     public function __invoke(AddGitLabHook $message): void
     {
-        $package = $this->packages->getById(Uuid::fromString($message->packageId()));
+        $package = $this->packages->find(Uuid::fromString($message->packageId()));
+        if (!$package instanceof Package) {
+            return;
+        }
+
         $this->api->addHook(
             $package->oauthToken(),
             $package->metadata(Metadata::GITLAB_PROJECT_ID),

--- a/src/MessageHandler/Organization/SynchronizePackageHandler.php
+++ b/src/MessageHandler/Organization/SynchronizePackageHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Buddy\Repman\MessageHandler\Organization;
 
+use Buddy\Repman\Entity\Organization\Package;
 use Buddy\Repman\Message\Organization\SynchronizePackage;
 use Buddy\Repman\Repository\PackageRepository;
 use Buddy\Repman\Service\PackageSynchronizer;
@@ -23,7 +24,11 @@ final class SynchronizePackageHandler implements MessageHandlerInterface
 
     public function __invoke(SynchronizePackage $message): void
     {
-        $package = $this->packages->getById(Uuid::fromString($message->id()));
+        $package = $this->packages->find(Uuid::fromString($message->id()));
+        if (!$package instanceof Package) {
+            return;
+        }
+
         $this->synchronizer->synchronize($package);
     }
 }

--- a/tests/Integration/MessageHandler/Organization/Package/AddBitbucketHookHandlerTest.php
+++ b/tests/Integration/MessageHandler/Organization/Package/AddBitbucketHookHandlerTest.php
@@ -30,4 +30,16 @@ final class AddBitbucketHookHandlerTest extends IntegrationTestCase
 
         self::assertInstanceOf(\DateTimeImmutable::class, $package->get()->webhookCreatedAt());
     }
+
+    public function testHandlePackageNotFoundWithoutError(): void
+    {
+        $exception = null;
+        try {
+            $handler = $this->container()->get(AddBitbucketHookHandler::class);
+            $handler->__invoke(new AddBitbucketHook('e0ea4d32-4144-4a67-9310-6dae483a6377'));
+        } catch (\Exception $exception) {
+        }
+
+        self::assertNull($exception);
+    }
 }

--- a/tests/Integration/MessageHandler/Organization/Package/AddGitHubHookHandlerTest.php
+++ b/tests/Integration/MessageHandler/Organization/Package/AddGitHubHookHandlerTest.php
@@ -30,4 +30,16 @@ final class AddGitHubHookHandlerTest extends IntegrationTestCase
 
         self::assertInstanceOf(\DateTimeImmutable::class, $package->get()->webhookCreatedAt());
     }
+
+    public function testHandlePackageNotFoundWithoutError(): void
+    {
+        $exception = null;
+        try {
+            $handler = $this->container()->get(AddGitHubHookHandler::class);
+            $handler->__invoke(new AddGitHubHook('e0ea4d32-4144-4a67-9310-6dae483a6377'));
+        } catch (\Exception $exception) {
+        }
+
+        self::assertNull($exception);
+    }
 }

--- a/tests/Integration/MessageHandler/Organization/Package/AddGitLabHookHandlerTest.php
+++ b/tests/Integration/MessageHandler/Organization/Package/AddGitLabHookHandlerTest.php
@@ -30,4 +30,16 @@ final class AddGitLabHookHandlerTest extends IntegrationTestCase
 
         self::assertInstanceOf(\DateTimeImmutable::class, $package->get()->webhookCreatedAt());
     }
+
+    public function testHandlePackageNotFoundWithoutError(): void
+    {
+        $exception = null;
+        try {
+            $handler = $this->container()->get(AddGitLabHookHandler::class);
+            $handler->__invoke(new AddGitLabHook('e0ea4d32-4144-4a67-9310-6dae483a6377'));
+        } catch (\Exception $exception) {
+        }
+
+        self::assertNull($exception);
+    }
 }

--- a/tests/Integration/MessageHandler/Organization/Package/RemoveGitHubHookHandlerTest.php
+++ b/tests/Integration/MessageHandler/Organization/Package/RemoveGitHubHookHandlerTest.php
@@ -31,4 +31,13 @@ final class RemoveGitHubHookHandlerTest extends IntegrationTestCase
 
         self::assertEquals(null, $package->get()->webhookCreatedAt());
     }
+
+    public function testPackageNotFound(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Package 9691e73b-1738-42fe-9d5b-31d0dadf7407 not found.');
+
+        $handler = $this->container()->get(RemoveGitHubHookHandler::class);
+        $handler->__invoke(new RemoveGitHubHook('9691e73b-1738-42fe-9d5b-31d0dadf7407'));
+    }
 }

--- a/tests/Integration/MessageHandler/Organization/SynchronizePackageHandlerTest.php
+++ b/tests/Integration/MessageHandler/Organization/SynchronizePackageHandlerTest.php
@@ -25,7 +25,7 @@ final class SynchronizePackageHandlerTest extends IntegrationTestCase
         );
 
         $handler = $this->container()->get(SynchronizePackageHandler::class);
-        $handler(new SynchronizePackage($packageId));
+        $handler->__invoke(new SynchronizePackage($packageId));
         $this->container()->get('doctrine.orm.entity_manager')->flush();
 
         /** @var Package $package */
@@ -40,12 +40,15 @@ final class SynchronizePackageHandlerTest extends IntegrationTestCase
         self::assertEquals($date->format('Y-m-d H:i:s'), $releaseDate->format('Y-m-d H:i:s'));
     }
 
-    public function testPackageNotFound(): void
+    public function testHandlePackageNotFoundWithoutError(): void
     {
-        self::expectException(\InvalidArgumentException::class);
-        self::expectExceptionMessage('Package e0ea4d32-4144-4a67-9310-6dae483a6377 not found');
+        $exception = null;
+        try {
+            $handler = $this->container()->get(SynchronizePackageHandler::class);
+            $handler->__invoke(new SynchronizePackage('e0ea4d32-4144-4a67-9310-6dae483a6377'));
+        } catch (\Exception $exception) {
+        }
 
-        $handler = $this->container()->get(SynchronizePackageHandler::class);
-        $handler(new SynchronizePackage('e0ea4d32-4144-4a67-9310-6dae483a6377'));
+        self::assertNull($exception);
     }
 }


### PR DESCRIPTION
The motivation for this case is a situation in which the resource is no longer available, but there is still a message on the queue. In this case, unnecessarily log errors, because you can not do anything since the package has been removed.