### PR TITLE
Write custom Gitlab URL to gitlab-domains composer option. Fixes #165.

### DIFF
--- a/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
+++ b/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
@@ -140,6 +140,13 @@ final class ComposerPackageSynchronizer implements PackageSynchronizer
                 ],
             ],
         ]);
+        if ($package->type() === 'gitlab-oauth') {
+            $config->merge([
+                'config' => [
+                    'gitlab-domains' => [(string) parse_url($this->gitlabUrl, PHP_URL_HOST)],
+                ],
+            ]);
+        }
 
         return $config;
     }


### PR DESCRIPTION
When I add this, the GitLab sync does work.

See https://getcomposer.org/doc/06-config.md#gitlab-domains for what this option does.