### PR TITLE
Make the first user an admin

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -8,6 +8,7 @@ use Buddy\Repman\Form\Type\User\RegisterType;
 use Buddy\Repman\Message\User\ConfirmEmail;
 use Buddy\Repman\Message\User\CreateUser;
 use Buddy\Repman\Message\User\SendConfirmToken;
+use Buddy\Repman\Repository\UserRepository;
 use Buddy\Repman\Security\UserGuardHelper;
 use Buddy\Repman\Service\Config;
 use Ramsey\Uuid\Uuid;
@@ -21,11 +22,13 @@ class RegistrationController extends AbstractController
 {
     private UserGuardHelper $guard;
     private Config $config;
+    private UserRepository $users;
 
-    public function __construct(UserGuardHelper $guard, Config $config)
+    public function __construct(UserGuardHelper $guard, Config $config, UserRepository $users)
     {
         $this->guard = $guard;
         $this->config = $config;
+        $this->users = $users;
     }
 
     /**
@@ -44,7 +47,7 @@ class RegistrationController extends AbstractController
                 $email = $form->get('email')->getData(),
                 $form->get('plainPassword')->getData(),
                 $confirmToken = Uuid::uuid4()->toString(),
-                ['ROLE_USER']
+                $this->users->anyExists() ? ['ROLE_USER'] : ['ROLE_USER', 'ROLE_ADMIN'],
             ));
             $this->dispatchMessage(new SendConfirmToken(
                 $email,

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -95,4 +95,9 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     {
         $this->_em->remove($this->getById($id));
     }
+
+    public function anyExists(): bool
+    {
+        return $this->count([]) > 0;
+    }
 }


### PR DESCRIPTION
Currently the only way to create the first admin user is to update the record in the DB. This fixes it by making the first user an admin.

Two questions:
* I checked the existing (integration) test but it didn't test anything related to the roles, so I'm not sure if/how we can extend it. We could test in testSuccessfulRegistration that the body contains Administrator and in a separate test where we create a user with a fixture, that it does not?
* I'm not sure if putting the logic in the controller is the way to go. I tried looking at other places where this kind of logic resides but couldn't really find any.