### PR TITLE
Add support for showing all package versions. Refs #175.

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -49,6 +49,7 @@ security:
          - { path: ^/$, roles: ROLE_USER }
          - { path: ^/organization/.+/overview$, roles: ROLE_ORGANIZATION_ANONYMOUS_USER }
          - { path: ^/organization/.+/package$, roles: ROLE_ORGANIZATION_ANONYMOUS_USER }
+         - { path: ^/organization/.+/package/.+/details$, roles: ROLE_ORGANIZATION_ANONYMOUS_USER }
          - { path: ^/organization/.+(/.+)*, roles: ROLE_ORGANIZATION_MEMBER }
          - { path: ^/downloads, host: '([a-z0-9_-]+)\.repo\.(.+)', roles: IS_AUTHENTICATED_ANONYMOUSLY}
          - { path: ^/, host: '([a-z0-9_-]+)\.repo\.(.+)', roles: ROLE_ORGANIZATION }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,7 +20,7 @@ parameters:
             path: src/Service/Twig/DateExtension.php
         -
             message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-            count: 2
+            count: 4
             path: src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
         -
             message: "#^Variable \\$http_response_header in isset\\(\\) always exists and is not nullable\\.$#"

--- a/src/Controller/OrganizationController.php
+++ b/src/Controller/OrganizationController.php
@@ -142,6 +142,19 @@ final class OrganizationController extends AbstractController
     }
 
     /**
+     * @Route("/organization/{organization}/package/{package}/details", name="organization_package_details", methods={"GET"}, requirements={"organization"="%organization_pattern%","package"="%uuid_pattern%"})
+     */
+    public function packageDetails(Organization $organization, Package $package, Request $request): Response
+    {
+        return $this->render('organization/package/details.html.twig', [
+            'organization' => $organization,
+            'package' => $package,
+            'count' => $this->packageQuery->versionCount($package->id()),
+            'versions' => $this->packageQuery->getVersions($package->id(), 20, (int) $request->get('offset', 0)),
+        ]);
+    }
+
+    /**
      * @Route("/organization/{organization}/package/{package}/stats", name="organization_package_stats", methods={"GET"}, requirements={"organization"="%organization_pattern%","package"="%uuid_pattern%"})
      */
     public function packageStats(Organization $organization, Package $package, Request $request): Response

--- a/src/Entity/Organization/Package/Version.php
+++ b/src/Entity/Organization/Package/Version.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Entity\Organization\Package;
+
+use Buddy\Repman\Entity\Organization\Package;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(
+ *     name="organization_package_version",
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="package_version", columns={"package_id", "version"})},
+ *     indexes={
+ *      @ORM\Index(name="version_package_id_idx", columns={"package_id"}),
+ *      @ORM\Index(name="version_date_idx", columns={"date"})
+ *     }
+ * )
+ */
+class Version
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="uuid")
+     */
+    private UuidInterface $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Buddy\Repman\Entity\Organization\Package", inversedBy="versions")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     */
+    private Package $package;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private string $version;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private string $reference;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private int $size;
+
+    /**
+     * @ORM\Column(type="datetime_immutable")
+     */
+    private \DateTimeImmutable $date;
+
+    public function __construct(
+        UuidInterface $id,
+        string $version,
+        string $reference,
+        int $size,
+        \DateTimeImmutable $date
+    ) {
+        $this->id = $id;
+        $this->version = $version;
+        $this->reference = $reference;
+        $this->size = $size;
+        $this->date = $date;
+    }
+
+    public function id(): UuidInterface
+    {
+        return $this->id;
+    }
+
+    public function version(): string
+    {
+        return $this->version;
+    }
+
+    public function reference(): string
+    {
+        return $this->reference;
+    }
+
+    public function size(): int
+    {
+        return $this->size;
+    }
+
+    public function setReference(string $reference): void
+    {
+        $this->reference = $reference;
+    }
+
+    public function setSize(int $size): void
+    {
+        $this->size = $size;
+    }
+
+    public function setPackage(Package $package): void
+    {
+        if (isset($this->package)) {
+            throw new \RuntimeException('You can not change version package');
+        }
+        $this->package = $package;
+    }
+}

--- a/src/Migrations/Version20200706181929.php
+++ b/src/Migrations/Version20200706181929.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200706181929 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE organization_package_version (id UUID NOT NULL, package_id UUID NOT NULL, version VARCHAR(255) NOT NULL, reference VARCHAR(255) NOT NULL, size INT NOT NULL, date TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX version_package_id_idx ON organization_package_version (package_id)');
+        $this->addSql('CREATE INDEX version_date_idx ON organization_package_version (date)');
+        $this->addSql('CREATE UNIQUE INDEX package_version ON organization_package_version (package_id, version)');
+        $this->addSql('COMMENT ON COLUMN organization_package_version.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN organization_package_version.package_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN organization_package_version.date IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE organization_package_version ADD CONSTRAINT FK_62DF469AF44CABFF FOREIGN KEY (package_id) REFERENCES organization_package (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP TABLE organization_package_version');
+    }
+}

--- a/src/Query/User/Model/Version.php
+++ b/src/Query/User/Model/Version.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Query\User\Model;
+
+final class Version
+{
+    private string $version;
+    private string $reference;
+    private int $size;
+    private \DateTimeImmutable $date;
+
+    public function __construct(string $version, string $reference, int $size, \DateTimeImmutable $date)
+    {
+        $this->version = $version;
+        $this->reference = $reference;
+        $this->size = $size;
+        $this->date = $date;
+    }
+
+    public function version(): string
+    {
+        return $this->version;
+    }
+
+    public function reference(): string
+    {
+        return $this->reference;
+    }
+
+    public function size(): int
+    {
+        return $this->size;
+    }
+
+    public function date(): \DateTimeImmutable
+    {
+        return $this->date;
+    }
+}

--- a/src/Query/User/PackageQuery.php
+++ b/src/Query/User/PackageQuery.php
@@ -8,6 +8,7 @@ use Buddy\Repman\Query\User\Model\Installs;
 use Buddy\Repman\Query\User\Model\Package;
 use Buddy\Repman\Query\User\Model\PackageName;
 use Buddy\Repman\Query\User\Model\ScanResult;
+use Buddy\Repman\Query\User\Model\Version;
 use Buddy\Repman\Query\User\Model\WebhookRequest;
 use Munus\Control\Option;
 
@@ -29,6 +30,13 @@ interface PackageQuery
      * @return Option<Package>
      */
     public function getById(string $id): Option;
+
+    public function versionCount(string $packageId): int;
+
+    /**
+     * @return Version[]
+     */
+    public function getVersions(string $packageId, int $limit = 20, int $offset = 0): array;
 
     public function getInstalls(string $packageId, int $lastDays = 30, ?string $version = null): Installs;
 

--- a/src/Service/Dist/Storage.php
+++ b/src/Service/Dist/Storage.php
@@ -18,6 +18,8 @@ interface Storage
 
     public function filename(Dist $dist): string;
 
+    public function size(Dist $dist): int;
+
     /**
      * @return GenericList<string>
      */

--- a/src/Service/Dist/Storage/FileStorage.php
+++ b/src/Service/Dist/Storage/FileStorage.php
@@ -64,6 +64,13 @@ final class FileStorage implements Storage
         );
     }
 
+    public function size(Dist $dist): int
+    {
+        $size = filesize($this->filename($dist));
+
+        return $size === false ? 0 : $size;
+    }
+
     /**
      * @return GenericList<string>
      */

--- a/src/Service/Dist/Storage/InMemoryStorage.php
+++ b/src/Service/Dist/Storage/InMemoryStorage.php
@@ -43,6 +43,11 @@ final class InMemoryStorage implements Storage
         );
     }
 
+    public function size(Dist $dist): int
+    {
+        return 0;
+    }
+
     public function packages(string $repo): GenericList
     {
         return GenericList::ofAll($this->dists);

--- a/src/Service/Twig/BytesExtension.php
+++ b/src/Service/Twig/BytesExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Service\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class BytesExtension extends AbstractExtension
+{
+    /**
+     * @return TwigFilter[]
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('format_bytes', [$this, 'formatBytes']),
+        ];
+    }
+
+    public function formatBytes(int $bytes, int $precision = 2): string
+    {
+        $size = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        $factor = floor((strlen((string) $bytes) - 1) / 3);
+
+        return sprintf("%.{$precision}f", $bytes / (1024 ** $factor)).' '.$size[$factor];
+    }
+}

--- a/templates/organization/package/details.html.twig
+++ b/templates/organization/package/details.html.twig
@@ -1,0 +1,105 @@
+{% extends 'base.html.twig' %}
+
+{% block header %}{{ package.name }} details{% endblock %}
+{% block header_btn %}
+    <a href="{{ path('organization_packages', {"organization":organization.alias}) }}" class="btn btn-primary">
+        {% include 'svg/package.svg' %} Package list
+    </a>
+{% endblock %}
+
+{% block content %}
+
+    {% if package.name %}
+        <div class="row">
+            <div class="col-6">
+                <h4>Package name</h4>
+                <p>{{ package.name }}</p>
+            </div>
+            <div class="col-6">
+                <h4>Description</h4>
+                <p>{{ package.description }}</p>
+            </div>
+        </div>
+
+        {% if package.latestReleaseDate %}
+            <div class="row">
+                <div class="col-6">
+                    <h4>Latest version</h4>
+                    <p>{{ package.latestReleasedVersion }} (released: <span title="{{ package.latestReleaseDate | date('Y-m-d H:i:s') }}">{{ package.latestReleaseDate | time_diff }}</span>)</p>
+                </div>
+                <div class="col-6">
+                    <h4>Composer require command</h4>
+                    <div class="row">
+                        <div class="input-group col-11">
+                            <input id="composer-require" class="form-control" readonly value="composer require {{ package.name }}"/>
+                            <span class="input-group-append">
+                        <button data-clipboard-target="#composer-require" class="copy-to-clipboard btn btn-primary p-2" type="button" data-toggle="tooltip" data-placement="top" data-content="Copy composer require command">
+                            {% include 'svg/clipboard.svg' %}
+                        </button>
+                    </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
+        <hr />
+
+        <h3>Available versions</h3>
+
+        {% if count == 0 %}
+            <p>
+                To see available versions of the package, please perform synchronization again.
+            </p>
+            <a
+                data-target="confirmation"
+                data-action="{{ path('organization_package_update', {organization: organization.alias, package: package.id }) }}"
+                data-method="POST"
+                href="#"
+                class="btn btn-success">
+                {% include 'svg/refresh.svg' %} Sync now
+            </a>
+        {% else %}
+            <table class="table">
+                <thead>
+                <tr>
+                    <th>Version</th>
+                    <th>Released</th>
+                    <th>Reference</th>
+                    <th>Size</th>
+                    <th></th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for version in versions %}
+                    <tr>
+                        <td>{{ version.version }}</td>
+                        <td>
+                            <span title="{{ version.date | date('Y-m-d H:i:s') }}">{{ version.date | time_diff }}</span>
+                        </td>
+                        <td>{{ version.reference }}</td>
+                        <td>{{ version.size | format_bytes }}</td>
+                        <td>
+                            <div class="input-group">
+                                <input id="version-{{ version.reference }}" class="form-control" readonly value="composer require {{ package.name }}:{{ version.version }}"/>
+                                <span class="input-group-append">
+                            <button data-clipboard-target="#version-{{ version.reference }}" class="copy-to-clipboard btn btn-primary p-2" type="button" data-toggle="tooltip" data-placement="top"
+                                    data-content="Copy composer require command for version to clipboard">
+                                {% include 'svg/clipboard.svg' %}
+                            </button>
+                        </span>
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            {% include 'component/pagination.html.twig' with {'path_name': 'organization_package_details', 'path_params': {'organization': organization.alias, 'package': package.id}} %}
+        {% endif %}
+    {% else %}
+        <div class="alert alert-warning">
+            This package is not synced yet!
+        </div>
+    {% endif %}
+
+{% endblock %}

--- a/templates/organization/packages.html.twig
+++ b/templates/organization/packages.html.twig
@@ -16,7 +16,7 @@
         <thead>
             <tr>
                 <th>Name</th>
-                <th>Version</th>
+                <th>Latest version</th>
                 <th>Released</th>
                 <th>Description</th>
                 {% if is_granted('ROLE_ORGANIZATION_MEMBER', organization) %}
@@ -31,7 +31,11 @@
                 <tr>
                     <td>
                         {% if package.name %}
-                            <strong>{{ package.name }}</strong><br />
+                            <strong>
+                                <a href="{{ path('organization_package_details', {organization: organization.alias, package: package.id}) }}">
+                                    {{ package.name }}
+                                </a>
+                            </strong><br />
                             <small class="font-italic" style="font-size: 0.7em"><a href="{{ package.url }}" target="_blank" rel="nofollow noopener noreferrer">
                                 {{ package.url }}
                             </a></small><br />
@@ -93,6 +97,9 @@
                                 <button class="btn btn-secondary dropdown-toggle align-text-top" data-toggle="dropdown">Actions</button>
                                 <div class="dropdown-menu">
                                 {% if package.name %}
+                                    <a href="{{ path('organization_package_details', {organization: organization.alias, package: package.id}) }}" class="dropdown-item">
+                                        {% include 'svg/package.svg' %} Details
+                                    </a>
                                     <a href="{{ path('organization_package_stats', {organization: organization.alias, package: package.id}) }}" class="dropdown-item">
                                         {% include 'svg/bar-chart.svg' %} Statistics
                                     </a>

--- a/tests/Integration/FixturesManager.php
+++ b/tests/Integration/FixturesManager.php
@@ -6,6 +6,7 @@ namespace Buddy\Repman\Tests\Integration;
 
 use Buddy\Repman\Entity\Organization\Member;
 use Buddy\Repman\Entity\Organization\Package\ScanResult;
+use Buddy\Repman\Entity\Organization\Package\Version;
 use Buddy\Repman\Message\Organization\AddDownload;
 use Buddy\Repman\Message\Organization\AddPackage;
 use Buddy\Repman\Message\Organization\CreateOrganization;
@@ -182,9 +183,12 @@ final class FixturesManager
         $this->container->get(EntityManagerInterface::class)->flush();
     }
 
-    public function syncPackageWithData(string $packageId, string $name, string $description, string $latestReleasedVersion, \DateTimeImmutable $latestReleaseDate): void
+    /**
+     * @param Version[] $versions
+     */
+    public function syncPackageWithData(string $packageId, string $name, string $description, string $latestReleasedVersion, \DateTimeImmutable $latestReleaseDate, array $versions = []): void
     {
-        $this->container->get(PackageSynchronizer::class)->setData($name, $description, $latestReleasedVersion, $latestReleaseDate);
+        $this->container->get(PackageSynchronizer::class)->setData($name, $description, $latestReleasedVersion, $latestReleaseDate, $versions);
         $this->dispatchMessage(new SynchronizePackage($packageId));
         $this->container->get(EntityManagerInterface::class)->flush();
     }

--- a/tests/MotherObject/PackageMother.php
+++ b/tests/MotherObject/PackageMother.php
@@ -53,7 +53,10 @@ final class PackageMother
         return $package;
     }
 
-    public static function synchronized(string $name, string $latestVersion, string $url = ''): Package
+    /**
+     * @param string[] $unencounteredVersions
+     */
+    public static function synchronized(string $name, string $latestVersion, string $url = '', array $unencounteredVersions = []): Package
     {
         $package = new Package(Uuid::uuid4(), 'path', $url);
         $package->setOrganization(new Organization(
@@ -66,6 +69,7 @@ final class PackageMother
             $name,
             'Package description',
             $latestVersion,
+            $unencounteredVersions,
             new \DateTimeImmutable()
         );
 

--- a/tests/Unit/Entity/PackageTest.php
+++ b/tests/Unit/Entity/PackageTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Buddy\Repman\Tests\Unit\Entity;
 
 use Buddy\Repman\Entity\Organization\Package;
+use Buddy\Repman\Entity\Organization\Package\Version;
 use Buddy\Repman\Tests\MotherObject\PackageMother;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
 
 final class PackageTest extends TestCase
 {
@@ -21,7 +23,21 @@ final class PackageTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $this->package->syncSuccess('../invalid/name', 'desc', '1.2.0.0', new \DateTimeImmutable());
+        $this->package->syncSuccess('../invalid/name', 'desc', '1.2.0.0', [], new \DateTimeImmutable());
+    }
+
+    public function testSyncSuccessRemovesUnencounteredVersions(): void
+    {
+        $this->package->addOrUpdateVersion($version1 = new Version(Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable()));
+        $this->package->addOrUpdateVersion($version2 = new Version(Uuid::uuid4(), '1.0.1', 'anotherref', 5678, new \DateTimeImmutable()));
+        $this->package->addOrUpdateVersion($version3 = new Version(Uuid::uuid4(), '1.1.0', 'lastref', 6543, new \DateTimeImmutable()));
+
+        $this->package->syncSuccess('some/package', 'desc', '1.1.0', ['1.0.0', '1.1.0'], new \DateTimeImmutable());
+
+        self::assertCount(2, $this->package->versions());
+        self::assertContains($version1, $this->package->versions());
+        self::assertNotContains($version2, $this->package->versions());
+        self::assertContains($version3, $this->package->versions());
     }
 
     public function testOuathTokenNotFound(): void
@@ -36,5 +52,49 @@ final class PackageTest extends TestCase
         $this->expectException(\RuntimeException::class);
 
         $this->package->metadata('not-exist');
+    }
+
+    public function testPackageGetProperties(): void
+    {
+        $version = new Version($id = Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable());
+        $this->package->addOrUpdateVersion($version);
+
+        self::assertInstanceOf(Version::class, $returnedVersion = $this->package->getVersion('1.0.0'));
+        self::assertEquals($id, $returnedVersion->id());
+        self::assertEquals('1.0.0', $returnedVersion->version());
+        self::assertEquals('someref', $returnedVersion->reference());
+        self::assertEquals(1234, $returnedVersion->size());
+    }
+
+    public function testPackageNonExisting(): void
+    {
+        $version = new Version(Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable());
+        $this->package->addOrUpdateVersion($version);
+
+        self::assertEquals(false, $this->package->getVersion('1.0.1'));
+    }
+
+    public function testPackageUpdateVersion(): void
+    {
+        $version = new Version($id1 = Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable());
+        $versionUpdated = new Version($id2 = Uuid::uuid4(), '1.0.0', 'newref', 5678, new \DateTimeImmutable());
+        $this->package->addOrUpdateVersion($version);
+        $this->package->addOrUpdateVersion($versionUpdated);
+
+        self::assertInstanceOf(Version::class, $returnedVersion = $this->package->getVersion('1.0.0'));
+        self::assertEquals($id1, $returnedVersion->id()); // We don't update the ID
+        self::assertEquals('1.0.0', $returnedVersion->version());
+        self::assertEquals('newref', $returnedVersion->reference());
+        self::assertEquals(5678, $returnedVersion->size());
+    }
+
+    public function testPackageAddSameVersion(): void
+    {
+        $version = new Version(Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable());
+        $this->package->addOrUpdateVersion($version);
+        $this->package->addOrUpdateVersion($version); // this should not throw exception
+
+        $this->expectException(\RuntimeException::class);
+        $version->setPackage($this->package);
     }
 }

--- a/tests/Unit/Service/Twig/BytesExtensionTest.php
+++ b/tests/Unit/Service/Twig/BytesExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Tests\Unit\Service\Twig;
+
+use Buddy\Repman\Service\Twig\BytesExtension;
+use PHPUnit\Framework\TestCase;
+
+final class BytesExtensionTest extends TestCase
+{
+    private BytesExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new BytesExtension();
+    }
+
+    public function testGetFilters(): void
+    {
+        self::assertEquals('format_bytes', $this->extension->getFilters()[0]->getName());
+    }
+
+    /**
+     * @dataProvider formatBytesProvider
+     */
+    public function testFormatBytes(string $expected, int $bytes, int $precision): void
+    {
+        self::assertEquals($expected, $this->extension->formatBytes($bytes, $precision));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function formatBytesProvider(): array
+    {
+        return [
+            ['1 KB', 1024, 0],
+            ['1.0 KB', 1024, 1],
+            ['1.00 KB', 1024, 2],
+            ['1.23 KB', 1260, 2],
+            ['5.75 MB', 6029312, 2],
+            ['13.37 GB', 14355928186, 2],
+        ];
+    }
+}


### PR DESCRIPTION
In #175 there was a request to show the package versions. Since that is also a very useful feature for us, I have added this functionality.

Some notes / remarks:
* I added a package details page so one can view the versions here. We could later possibly add more here (like the readme). I made anonymous organization users have access to it.
* You can get to the details page both using the dropdown menu as well as clicking the package name.
* Does showing the clipboard button make sense? For `dev-*` versions this is what you want but for other versions you might want to add `^` or `~` in front of it. Maybe only let one copy the version itself as well as a separate button to copy the package name?
* I'm not sure if my logic in the Package and Version entity make sense?
* Perhaps we should add a `stable` boolean to version so we can show the `dev-*` versions in a separate table?
* I modified some tests to also test if we have the correct versions, but I'm not sure how/if we should test the reference as well? We could do it for the artifact case, since these ZIP's should have versions. For the local path one we can't assume anything since it uses local git info.

Some screenshots:
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/550145/86511647-69f00500-bdfb-11ea-9993-eaa521291349.png">
<img width="1387" alt="image" src="https://user-images.githubusercontent.com/550145/86511650-6fe5e600-bdfb-11ea-9e4f-cc08c0042ab6.png">
