### PR TITLE
Add support for IPv6 addresses

### DIFF
--- a/src/Entity/Organization/Package/Download.php
+++ b/src/Entity/Organization/Package/Download.php
@@ -43,7 +43,7 @@ class Download
     private string $version;
 
     /**
-     * @ORM\Column(type="string", length=15, nullable=true)
+     * @ORM\Column(type="string", length=39, nullable=true)
      */
     private ?string $ip;
 

--- a/src/Migrations/Version20200713195731.php
+++ b/src/Migrations/Version20200713195731.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200713195731 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE organization_package_download ALTER ip TYPE VARCHAR(39)');
+        $this->addSql('ALTER TABLE organization_package_webhook_request ALTER COLUMN ip TYPE VARCHAR(39)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE organization_package_webhook_request ALTER COLUMN ip TYPE VARCHAR(15)');
+        $this->addSql('ALTER TABLE organization_package_download ALTER ip TYPE VARCHAR(15)');
+    }
+}


### PR DESCRIPTION
Currently running the webhook from an IPv6 enabled GitLab to an IPv6 enabled Repman gives this error:

```
[2020-07-13T21:49:10.318007+02:00] messenger.INFO: Sending message Buddy\Repman\Message\Organization\SynchronizePackage with Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransport {"message":{"Buddy\\Repman\\Message\\Organization\\SynchronizePackage":[]},"class":"Buddy\\Repman\\Message\\Organization\\SynchronizePackage","sender":"Symfony\\Component\\Messenger\\Transport\\Doctrine\\DoctrineTransport"} []
[2020-07-13T21:49:10.324592+02:00] request.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\DriverException: "An exception occurred while executing 'INSERT INTO organization_package_webhook_request (package_id, date, ip, user_agent) VALUES (?, ?, ?, ?)' with params ["5a3755fc-d428-4c31-a866-308aff689276", "2020-07-13 21:49:10", "2001:1af8:4f00:b018:48d3:9ff:feab:e2bd", null]:  SQLSTATE[22001]: String data, right truncated: 7 ERROR:  value too long for type character varying(15)" at /var/www/repman/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php line 79 {"exception":"[object] (Doctrine\\DBAL\\Exception\\DriverException(code: 0): An exception occurred while executing 'INSERT INTO organization_package_webhook_request (package_id, date, ip, user_agent) VALUES (?, ?, ?, ?)' with params [\"5a3755fc-d428-4c31-a866-308aff689276\", \"2020-07-13 21:49:10\", \"2001:1af8:4f00:b018:48d3:9ff:feab:e2bd\", null]:\n\nSQLSTATE[22001]: String data, right truncated: 7 ERROR:  value too long for type character varying(15) at /var/www/repman/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php:79)\n[previous exception] [object] (Doctrine\\DBAL\\Driver\\PDOException(code: 22001): SQLSTATE[22001]: String data, right truncated: 7 ERROR:  value too long for type character varying(15) at /var/www/repman/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:129)\n[previous exception] [object] (PDOException(code: 22001): SQLSTATE[22001]: String data, right truncated: 7 ERROR:  value too long for type character varying(15) at /var/www/repman/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:127)"} []
```

IPv6 addresses can be 39 characters long (8 groups of 4 characters and 7 `:`'s maximum) so we increase the size of the IP fields in the database to this.