### PR TITLE
Dockerfile: Install subversion client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk update && \
     $PHPIZE_DEPS \
     bash \
     git \
+    subversion \
     zip \
     unzip \
     postgresql-dev \


### PR DESCRIPTION
Install subversion client in dockerfile to enable support for subversion.