### PR TITLE
Update version date when updating

### DIFF
--- a/src/Entity/Organization/Package.php
+++ b/src/Entity/Organization/Package.php
@@ -278,6 +278,7 @@ class Package
         if ($this->getVersion($version->version()) !== false) {
             $this->getVersion($version->version())->setReference($version->reference());
             $this->getVersion($version->version())->setSize($version->size());
+            $this->getVersion($version->version())->setDate($version->date());
 
             return;
         }

--- a/src/Entity/Organization/Package/Version.php
+++ b/src/Entity/Organization/Package/Version.php
@@ -87,6 +87,11 @@ class Version
         return $this->size;
     }
 
+    public function date(): \DateTimeImmutable
+    {
+        return $this->date;
+    }
+
     public function setReference(string $reference): void
     {
         $this->reference = $reference;
@@ -95,6 +100,11 @@ class Version
     public function setSize(int $size): void
     {
         $this->size = $size;
+    }
+
+    public function setDate(\DateTimeImmutable $date): void
+    {
+        $this->date = $date;
     }
 
     public function setPackage(Package $package): void

--- a/tests/Unit/Entity/PackageTest.php
+++ b/tests/Unit/Entity/PackageTest.php
@@ -56,7 +56,8 @@ final class PackageTest extends TestCase
 
     public function testPackageGetProperties(): void
     {
-        $version = new Version($id = Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable());
+        $date = new \DateTimeImmutable();
+        $version = new Version($id = Uuid::uuid4(), '1.0.0', 'someref', 1234, $date);
         $this->package->addOrUpdateVersion($version);
 
         self::assertInstanceOf(Version::class, $returnedVersion = $this->package->getVersion('1.0.0'));
@@ -64,6 +65,7 @@ final class PackageTest extends TestCase
         self::assertEquals('1.0.0', $returnedVersion->version());
         self::assertEquals('someref', $returnedVersion->reference());
         self::assertEquals(1234, $returnedVersion->size());
+        self::assertEquals($date, $returnedVersion->date());
     }
 
     public function testPackageNonExisting(): void
@@ -76,8 +78,10 @@ final class PackageTest extends TestCase
 
     public function testPackageUpdateVersion(): void
     {
-        $version = new Version($id1 = Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable());
-        $versionUpdated = new Version($id2 = Uuid::uuid4(), '1.0.0', 'newref', 5678, new \DateTimeImmutable());
+        $date = new \DateTimeImmutable('tomorrow');
+        // Make sure the dates do not match so we can test that it is updated
+        $version = new Version($id1 = Uuid::uuid4(), '1.0.0', 'someref', 1234, new \DateTimeImmutable('today'));
+        $versionUpdated = new Version($id2 = Uuid::uuid4(), '1.0.0', 'newref', 5678, $date);
         $this->package->addOrUpdateVersion($version);
         $this->package->addOrUpdateVersion($versionUpdated);
 
@@ -86,6 +90,7 @@ final class PackageTest extends TestCase
         self::assertEquals('1.0.0', $returnedVersion->version());
         self::assertEquals('newref', $returnedVersion->reference());
         self::assertEquals(5678, $returnedVersion->size());
+        self::assertEquals($date, $returnedVersion->date());
     }
 
     public function testPackageAddSameVersion(): void


### PR DESCRIPTION
I noticed that the version thingy I created didn't update the date when a version is updated. This fixes that.