### PR TITLE
Package search

### DIFF
--- a/src/Controller/OrganizationController.php
+++ b/src/Controller/OrganizationController.php
@@ -69,14 +69,22 @@ final class OrganizationController extends AbstractController
      */
     public function packages(Organization $organization, Request $request): Response
     {
-        $count = $this->packageQuery->count($organization->id());
+        $count = $this->packageQuery->count($organization->id()); // @todo
         $user = parent::getUser();
         if ($count === 0 && $user instanceof User && $organization->isOwner($user->id())) {
             return $this->redirectToRoute('organization_package_new', ['organization' => $organization->alias()]);
         }
 
+        $searchTerm = $request->get('search');
+
+        if ($searchTerm) {
+            $packages = $this->packageQuery->find($organization->id(), $searchTerm, 20, (int) $request->get('offset', 0));
+        } else {
+            $packages = $this->packageQuery->findAll($organization->id(), 20, (int) $request->get('offset', 0));
+        }
+
         return $this->render('organization/packages.html.twig', [
-            'packages' => $this->packageQuery->findAll($organization->id(), 20, (int) $request->get('offset', 0)),
+            'packages' => $packages,
             'count' => $count,
             'organization' => $organization,
         ]);

--- a/src/Controller/ProxyController.php
+++ b/src/Controller/ProxyController.php
@@ -60,7 +60,7 @@ final class ProxyController extends AbstractController
      *     requirements={"package"="%package_name_pattern%","domain"="%domain%"},
      *     methods={"GET"})
      */
-    public function legacyMetadata(string $package): Response
+    public function legacyMetadata(string $package, Request $request): Response
     {
         /** @var Metadata $metadata */
         $metadata = $this->register->all()
@@ -69,7 +69,7 @@ final class ProxyController extends AbstractController
             ->map(fn (Option $option) => $option->get())
             ->getOrElse(Metadata::fromString('{"packages": {}}'));
 
-        return (new StreamedResponse(ResponseCallback::fromStream($metadata->stream()), 200, [
+        $response = (new StreamedResponse(null, 200, [
             'Accept-Ranges' => 'bytes',
             'Content-Type' => 'application/json',
             /* @phpstan-ignore-next-line */
@@ -78,6 +78,14 @@ final class ProxyController extends AbstractController
             ->setPublic()
             ->setLastModified((new \DateTime())->setTimestamp($metadata->timestamp()))
         ;
+
+        if ($response->isNotModified($request)) {
+            return $response;
+        }
+
+        $response->setCallback(ResponseCallback::fromStream($metadata->stream()));
+
+        return $response;
     }
 
     /**
@@ -88,7 +96,7 @@ final class ProxyController extends AbstractController
      *     requirements={"package"="%package_name_pattern%","domain"="%domain%"},
      *     methods={"GET"})
      */
-    public function metadata(string $package): Response
+    public function metadata(string $package, Request $request): Response
     {
         /** @var Metadata $metadata */
         $metadata = $this->register->all()
@@ -97,7 +105,7 @@ final class ProxyController extends AbstractController
             ->map(fn (Option $option) => $option->get())
             ->getOrElseThrow(new NotFoundHttpException());
 
-        return (new StreamedResponse(ResponseCallback::fromStream($metadata->stream()), 200, [
+        $response = (new StreamedResponse(null, 200, [
             'Accept-Ranges' => 'bytes',
             'Content-Type' => 'application/json',
             /* @phpstan-ignore-next-line */
@@ -106,6 +114,14 @@ final class ProxyController extends AbstractController
             ->setPublic()
             ->setLastModified((new \DateTime())->setTimestamp($metadata->timestamp()))
         ;
+
+        if ($response->isNotModified($request)) {
+            return $response;
+        }
+
+        $response->setCallback(ResponseCallback::fromStream($metadata->stream()));
+
+        return $response;
     }
 
     /**

--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -55,12 +55,12 @@ final class Filter
     public function getQueryStringParams(): array
     {
         $params = [
-            'offset' => (string)$this->getOffset(),
-            'limit' => (string)$this->getLimit(),
+            'offset' => (string) $this->getOffset(),
+            'limit' => (string) $this->getLimit(),
         ];
 
         if ($this->hasSearchTerm()) {
-            $params['search'] = (string)$this->getSearchTerm();
+            $params['search'] = (string) $this->getSearchTerm();
         }
 
         return $params;

--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -14,12 +14,16 @@ final class Filter
 
     public function __construct(int $offset = 0, int $limit = 20, ?string $searchTerm = null)
     {
-        if ($offset > 0) {
+        if ($offset >= 0) {
             $this->offset = $offset;
         }
 
         if ($limit >= 0) {
             $this->limit = $limit;
+        }
+
+        if ($this->limit > 100) {
+            $this->limit = 100;
         }
 
         $this->searchTerm = $searchTerm;
@@ -30,23 +34,9 @@ final class Filter
         return $this->offset;
     }
 
-    public function setOffset(int $offset): Filter
-    {
-        $this->offset = $offset;
-
-        return $this;
-    }
-
     public function getLimit(): int
     {
         return $this->limit;
-    }
-
-    public function setLimit(int $limit): Filter
-    {
-        $this->limit = $limit;
-
-        return $this;
     }
 
     public function getSearchTerm(): ?string
@@ -54,16 +44,23 @@ final class Filter
         return $this->searchTerm;
     }
 
-    public function setSearchTerm(?string $searchTerm): Filter
-    {
-        $this->searchTerm = $searchTerm;
-
-        return $this;
-    }
-
     public function hasSearchTerm(): bool
     {
         return $this->searchTerm !== null;
+    }
+
+    public function getQueryStringParams(): array
+    {
+        $params = [
+            'offset' => $this->getOffset(),
+            'limit' => $this->getLimit(),
+        ];
+
+        if ($this->hasSearchTerm()) {
+            $params['search'] = $this->getSearchTerm();
+        }
+
+        return $params;
     }
 
     public static function fromRequest(Request $request): Filter

--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -49,15 +49,18 @@ final class Filter
         return $this->searchTerm !== null;
     }
 
+    /**
+     * @return array<string,string>
+     */
     public function getQueryStringParams(): array
     {
         $params = [
-            'offset' => $this->getOffset(),
-            'limit' => $this->getLimit(),
+            'offset' => (string)$this->getOffset(),
+            'limit' => (string)$this->getLimit(),
         ];
 
         if ($this->hasSearchTerm()) {
-            $params['search'] = $this->getSearchTerm();
+            $params['search'] = (string)$this->getSearchTerm();
         }
 
         return $params;

--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -10,7 +10,20 @@ final class Filter
 {
     private int $offset = 0;
     private int $limit = 20;
-    private ?string $searchTerm = null;
+    private ?string $searchTerm;
+
+    public function __construct(int $offset = 0, int $limit = 20, ?string $searchTerm = null)
+    {
+        if ($offset > 0) {
+            $this->offset = $offset;
+        }
+
+        if ($limit >= 0) {
+            $this->limit = $limit;
+        }
+
+        $this->searchTerm = $searchTerm;
+    }
 
     public function getOffset(): int
     {
@@ -48,23 +61,17 @@ final class Filter
         return $this;
     }
 
+    public function hasSearchTerm(): bool
+    {
+        return $this->searchTerm !== null;
+    }
+
     public static function fromRequest(Request $request): Filter
     {
-        $limit = (int) $request->get('limit', 20);
-
-        if ($limit <= 0) {
-            $limit = 20;
-        }
-
-        $offset = (int) $request->get('offset', 0);
-
-        if ($offset < 0) {
-            $offset = 0;
-        }
-
-        return (new self())
-            ->setOffset($offset)
-            ->setLimit($limit)
-            ->setSearchTerm($request->get('search', null));
+        return new self(
+            (int) $request->get('offset', 0),
+            (int) $request->get('limit', 20),
+            $request->get('search', null)
+        );
     }
 }

--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -20,6 +20,7 @@ final class Filter
     public function setOffset(int $offset): Filter
     {
         $this->offset = $offset;
+
         return $this;
     }
 
@@ -31,6 +32,7 @@ final class Filter
     public function setLimit(int $limit): Filter
     {
         $this->limit = $limit;
+
         return $this;
     }
 
@@ -42,6 +44,7 @@ final class Filter
     public function setSearchTerm(?string $searchTerm): Filter
     {
         $this->searchTerm = $searchTerm;
+
         return $this;
     }
 

--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Query;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class Filter
+{
+    private int $offset = 0;
+    private int $limit = 20;
+    private ?string $searchTerm = null;
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function setOffset(int $offset): Filter
+    {
+        $this->offset = $offset;
+        return $this;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(int $limit): Filter
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function getSearchTerm(): ?string
+    {
+        return $this->searchTerm;
+    }
+
+    public function setSearchTerm(?string $searchTerm): Filter
+    {
+        $this->searchTerm = $searchTerm;
+        return $this;
+    }
+
+    public static function fromRequest(Request $request): Filter
+    {
+        $limit = (int) $request->get('limit', 20);
+
+        if ($limit <= 0) {
+            $limit = 20;
+        }
+
+        $offset = (int) $request->get('offset', 0);
+
+        if ($offset < 0) {
+            $offset = 0;
+        }
+
+        return (new self())
+            ->setOffset($offset)
+            ->setLimit($limit)
+            ->setSearchTerm($request->get('search', null));
+    }
+}

--- a/src/Query/User/PackageQuery.php
+++ b/src/Query/User/PackageQuery.php
@@ -20,6 +20,11 @@ interface PackageQuery
     public function findAll(string $organizationId, int $limit = 20, int $offset = 0): array;
 
     /**
+     * @return Package[]
+     */
+    public function find(string $organizationId, string $searchString, int $limit = 20, int $offset = 0): array;
+
+    /**
      * @return PackageName[]
      */
     public function getAllNames(string $organizationId): array;

--- a/src/Query/User/PackageQuery.php
+++ b/src/Query/User/PackageQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Buddy\Repman\Query\User;
 
+use Buddy\Repman\Query\Filter;
 use Buddy\Repman\Query\User\Model\Installs;
 use Buddy\Repman\Query\User\Model\Package;
 use Buddy\Repman\Query\User\Model\PackageName;
@@ -17,19 +18,14 @@ interface PackageQuery
     /**
      * @return Package[]
      */
-    public function findAll(string $organizationId, int $limit = 20, int $offset = 0): array;
+    public function findAll(string $organizationId, Filter $filter): array;
 
-    /**
-     * @return Package[]
-     */
-    public function find(string $organizationId, string $searchString, int $limit = 20, int $offset = 0): array;
+    public function count(string $organizationId, Filter $filter): int;
 
     /**
      * @return PackageName[]
      */
     public function getAllNames(string $organizationId): array;
-
-    public function count(string $organizationId): int;
 
     /**
      * @return Option<Package>

--- a/src/Query/User/PackageQuery/DbalPackageQuery.php
+++ b/src/Query/User/PackageQuery/DbalPackageQuery.php
@@ -39,7 +39,7 @@ final class DbalPackageQuery implements PackageQuery
 
         if ($filter->hasSearchTerm()) {
             $filterSQL = ' AND (name ILIKE :term OR description ILIKE :term) ';
-            $params[':term'] = $filter->getSearchTerm();
+            $params[':term'] = '%'.$filter->getSearchTerm().'%';
         }
 
         return array_map(
@@ -98,7 +98,7 @@ final class DbalPackageQuery implements PackageQuery
 
         if ($filter->hasSearchTerm()) {
             $filterSQL = ' AND (name ILIKE :term OR description ILIKE :term)';
-            $params[':term'] = $filter->getSearchTerm();
+            $params[':term'] = '%'.$filter->getSearchTerm().'%';
         }
 
         return (int) $this

--- a/src/Query/User/PackageQuery/DbalPackageQuery.php
+++ b/src/Query/User/PackageQuery/DbalPackageQuery.php
@@ -50,7 +50,7 @@ final class DbalPackageQuery implements PackageQuery
                 last_scan_result
             FROM organization_package
             WHERE organization_id = :organization_id
-            AND (name LIKE :namesearch OR description LIKE :descsearch)
+            AND (name ILIKE :namesearch OR description ILIKE :descsearch)
             GROUP BY id
             ORDER BY name ASC
             LIMIT :limit OFFSET :offset', [
@@ -85,7 +85,7 @@ final class DbalPackageQuery implements PackageQuery
             ->fetchColumn(
                 'SELECT COUNT(id) FROM "organization_package"
                 WHERE organization_id = :organization_id
-                AND (name LIKE :namesearch OR description LIKE :descsearch)',
+                AND (name ILIKE :namesearch OR description ILIKE :descsearch)',
                 [
                     ':organization_id' => $organizationId,
                     ':namesearch' => '%'.$filter->getSearchTerm().'%',

--- a/src/Query/User/PackageQuery/DbalPackageQuery.php
+++ b/src/Query/User/PackageQuery/DbalPackageQuery.php
@@ -59,6 +59,42 @@ final class DbalPackageQuery implements PackageQuery
     }
 
     /**
+     * @return Package[]
+     */
+    public function find(string $organizationId, string $searchString, int $limit = 20, int $offset = 0): array
+    {
+        return array_map(function (array $data): Package {
+            return $this->hydratePackage($data);
+        }, $this->connection->fetchAll(
+            'SELECT
+                id,
+                organization_id,
+                type,
+                repository_url,
+                name,
+                latest_released_version,
+                latest_release_date,
+                description,
+                last_sync_at,
+                last_sync_error,
+                webhook_created_at,
+                last_scan_date,
+                last_scan_status,
+                last_scan_result
+            FROM organization_package
+            WHERE organization_id = :organization_id
+            AND name LIKE :search
+            GROUP BY id
+            ORDER BY name ASC
+            LIMIT :limit OFFSET :offset', [
+            ':organization_id' => $organizationId,
+            ':search' => '%' . $searchString . '%',
+            ':limit' => $limit,
+            ':offset' => $offset,
+        ]));
+    }
+
+    /**
      * @return PackageName[]
      */
     public function getAllNames(string $organizationId): array

--- a/src/Query/User/PackageQuery/DbalPackageQuery.php
+++ b/src/Query/User/PackageQuery/DbalPackageQuery.php
@@ -57,8 +57,8 @@ final class DbalPackageQuery implements PackageQuery
                 ':organization_id' => $organizationId,
                 ':limit' => $filter->getLimit(),
                 ':offset' => $filter->getOffset(),
-                ':namesearch' => '%' . $filter->getSearchTerm() . '%',
-                ':descsearch' => '%' . $filter->getSearchTerm() . '%',
+                ':namesearch' => '%'.$filter->getSearchTerm().'%',
+                ':descsearch' => '%'.$filter->getSearchTerm().'%',
         ]));
     }
 
@@ -88,8 +88,8 @@ final class DbalPackageQuery implements PackageQuery
                 AND (name LIKE :namesearch OR description LIKE :descsearch)',
                 [
                     ':organization_id' => $organizationId,
-                    ':namesearch' => '%' . $filter->getSearchTerm() . '%',
-                    ':descsearch' => '%' . $filter->getSearchTerm() . '%',
+                    ':namesearch' => '%'.$filter->getSearchTerm().'%',
+                    ':descsearch' => '%'.$filter->getSearchTerm().'%',
                 ]
             );
     }

--- a/templates/component/pagination.html.twig
+++ b/templates/component/pagination.html.twig
@@ -8,7 +8,7 @@
             <ul class="pagination ml-auto">
                 {% for i in 0..(count/offset) %}
                     <li class="page-item {% if currentOffset == i*offset %}active{% endif %}">
-                        <a class="page-link" href="{{ path(path_name, {offset: i*offset} | merge(path_params | default({}))) }}">{{ i+1 }}</a>
+                        <a class="page-link" href="{{ path(path_name, (path_params | default({})) | merge({offset: i*offset})) }}">{{ i+1 }}</a>
                     </li>
                 {% endfor %}
             </ul>

--- a/templates/component/pagination.html.twig
+++ b/templates/component/pagination.html.twig
@@ -1,5 +1,5 @@
 {% set offset = offset | default(20) %}
-{% set currentOffset = app.request.query.get('offset', 0) %}
+{% set currentOffset = currentOffset | default(app.request.query.get('offset', 0)) %}
 
 {% if count > 0 and currentOffset <= count %}
     <div class="align-items-center d-flex">

--- a/templates/organization/packages.html.twig
+++ b/templates/organization/packages.html.twig
@@ -15,6 +15,22 @@
     <table class="table">
         <thead>
             <tr>
+                <td colspan="7">
+                    <form action="{{ path('organization_packages', {organization: organization.alias}) }}" method="get" class="form-inline">
+                        <label for="package-search" class="mr-2">Search:</label>
+                        <input type="search" id="package-search" name="search" value="{{ filter.searchTerm }}" class="form-control" />
+
+                        <label class="ml-auto text-right">
+                            Show
+                            <input type="number" name="limit" value="{{ filter.limit }}" class="form-control w-25 mx-2" min="1" />
+                            entries
+                        </label>
+
+                        <button class="btn btn-outline-primary btn-sm">Filter</button>
+                    </form>
+                </td>
+            </tr>
+            <tr>
                 <th>Name</th>
                 <th>Latest version</th>
                 <th>Released</th>
@@ -147,12 +163,12 @@
                 </tr>
             {% else %}
                 <tr>
-                    <td colspan="7" class="text-center">no packages added</td>
+                    <td colspan="7" class="text-center">No packages found</td>
                 </tr>
             {% endfor %}
         </tbody>
     </table>
-    {% include 'component/pagination.html.twig' with {'path_name': 'organization_packages', 'path_params': {'organization': organization.alias}} %}
+    {% include 'component/pagination.html.twig' with {'path_name': 'organization_packages', 'path_params': app.request.query|merge({'organization': organization.alias}), offset: filter.limit} %}
 </div>
 {% endblock %}
 

--- a/templates/organization/packages.html.twig
+++ b/templates/organization/packages.html.twig
@@ -168,7 +168,7 @@
             {% endfor %}
         </tbody>
     </table>
-    {% include 'component/pagination.html.twig' with {'path_name': 'organization_packages', 'path_params': app.request.query|merge({'organization': organization.alias}), offset: filter.limit} %}
+    {% include 'component/pagination.html.twig' with {'currentOffset': filter.offset, 'path_name': 'organization_packages', 'path_params': filter.getQueryStringParams()|merge({'organization': organization.alias}), offset: filter.limit} %}
 </div>
 {% endblock %}
 

--- a/tests/Integration/MessageHandler/Security/ScanPackageHandlerTest.php
+++ b/tests/Integration/MessageHandler/Security/ScanPackageHandlerTest.php
@@ -6,6 +6,7 @@ namespace Buddy\Repman\Tests\Integration\MessageHandler\Security;
 
 use Buddy\Repman\Message\Security\ScanPackage;
 use Buddy\Repman\MessageHandler\Security\ScanPackageHandler;
+use Buddy\Repman\Query\Filter;
 use Buddy\Repman\Query\User\PackageQuery;
 use Buddy\Repman\Tests\Integration\IntegrationTestCase;
 
@@ -31,7 +32,7 @@ final class ScanPackageHandlerTest extends IntegrationTestCase
         $package = $this
             ->container()
             ->get(PackageQuery::class)
-            ->findAll($this->organizationId)[0];
+            ->findAll($this->organizationId, new Filter)[0];
 
         self::assertEquals($package->scanResultStatus(), 'pending');
     }

--- a/tests/Integration/MessageHandler/Security/ScanPackageHandlerTest.php
+++ b/tests/Integration/MessageHandler/Security/ScanPackageHandlerTest.php
@@ -32,7 +32,7 @@ final class ScanPackageHandlerTest extends IntegrationTestCase
         $package = $this
             ->container()
             ->get(PackageQuery::class)
-            ->findAll($this->organizationId, new Filter)[0];
+            ->findAll($this->organizationId, new Filter())[0];
 
         self::assertEquals($package->scanResultStatus(), 'pending');
     }

--- a/tests/Integration/MessageHandler/Security/SendScanResultHandlerTest.php
+++ b/tests/Integration/MessageHandler/Security/SendScanResultHandlerTest.php
@@ -6,6 +6,7 @@ namespace Buddy\Repman\Tests\Integration\MessageHandler\Security;
 
 use Buddy\Repman\Message\Security\SendScanResult;
 use Buddy\Repman\MessageHandler\Security\SendScanResultHandler;
+use Buddy\Repman\Query\Filter;
 use Buddy\Repman\Query\User\PackageQuery;
 use Buddy\Repman\Tests\Integration\IntegrationTestCase;
 
@@ -37,7 +38,7 @@ final class SendScanResultHandlerTest extends IntegrationTestCase
         $package = $this
             ->container()
             ->get(PackageQuery::class)
-            ->findAll($this->organizationId)[0];
+            ->findAll($this->organizationId, new Filter)[0];
 
         self::assertEquals($package->scanResultStatus(), 'pending');
     }

--- a/tests/Integration/MessageHandler/Security/SendScanResultHandlerTest.php
+++ b/tests/Integration/MessageHandler/Security/SendScanResultHandlerTest.php
@@ -38,7 +38,7 @@ final class SendScanResultHandlerTest extends IntegrationTestCase
         $package = $this
             ->container()
             ->get(PackageQuery::class)
-            ->findAll($this->organizationId, new Filter)[0];
+            ->findAll($this->organizationId, new Filter())[0];
 
         self::assertEquals($package->scanResultStatus(), 'pending');
     }


### PR DESCRIPTION
Just want a bit of feedback/advice before I continue on this:
 - I'm thinking just an initial basic package name search for the time being, could be expanded to description (and maybe tags?) later
 - Currently, the pagination is done as two different calls to the `PackageQuery` class - to avoid having to add search functionality for each, could a paginator bundle be used instead? (I come from a Laravel background where it's a core part of the framework)
 - Design wise, I'm thinking that the search bar could be on the right of the title bar, to the left of 'Add package' 
![image](https://user-images.githubusercontent.com/305730/92328028-dedaf780-f055-11ea-90ca-ec1581b8d356.png)
 - Side note: could the hard-coded 20 per page be moved to a user setting? 
