### PR TITLE
Fix artifact repo security scan

### DIFF
--- a/src/Service/Security/PackageScanner/SensioLabsPackageScanner.php
+++ b/src/Service/Security/PackageScanner/SensioLabsPackageScanner.php
@@ -110,7 +110,7 @@ final class SensioLabsPackageScanner implements PackageScanner
         foreach ($providerData[$packageName] ?? [] as $packageData) {
             $packageVersion = $packageData['version_normalized'] ?? $this->versionParser->normalize($packageData['version']);
             $packageDist = $packageData['dist'];
-            $reference = $packageDist['reference'];
+            $reference = $packageDist['reference'] ?? $packageDist['shasum'];
 
             if ($packageVersion === $normalizedVersion && isset($packageDist['url'], $reference)) {
                 $archiveType = $packageDist['type'];


### PR DESCRIPTION
Non VCS repos don't have a reference. Repman uses the shasum instead for the Dist filename.