### PR TITLE
Test compatibility issues and small deprecation fix

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,8 +1,8 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__ . '/src')
-    ->in(__DIR__ . '/tests')
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests')
 ;
 
 $config = new PhpCsFixer\Config();

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,12 +1,11 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__.'/src')
-    ->in(__DIR__.'/tests')
-;
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests');
 
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
+$config = new PhpCsFixer\Config();
+return $config->setRiskyAllowed(true)
     ->setRules([
         '@PHP71Migration' => true,
         '@Symfony' => true,
@@ -34,10 +33,9 @@ return PhpCsFixer\Config::create()
         'global_namespace_import' => [
             'import_classes' => false,
             'import_constants' => false,
-            'import_functions' => false
+            'import_functions' => false,
         ],
         // risky -->
         'strict_param' => true,
     ])
-    ->setFinder($finder)
-;
+    ->setFinder($finder);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -2,7 +2,8 @@
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
-    ->in(__DIR__ . '/tests');
+    ->in(__DIR__ . '/tests')
+;
 
 $config = new PhpCsFixer\Config();
 return $config->setRiskyAllowed(true)
@@ -38,4 +39,5 @@ return $config->setRiskyAllowed(true)
         // risky -->
         'strict_param' => true,
     ])
-    ->setFinder($finder);
+    ->setFinder($finder)
+;

--- a/tests/Unit/Service/Security/SensioLabsSecurityCheckerTest.php
+++ b/tests/Unit/Service/Security/SensioLabsSecurityCheckerTest.php
@@ -23,7 +23,7 @@ final class SensioLabsSecurityCheckerTest extends TestCase
         $this->repoDir = sys_get_temp_dir().'/repman/security-advisories-repo';
         $this->filesystem = new Filesystem();
 
-        $this->checker = new SensioLabsSecurityChecker($this->dbDir, $this->repoDir);
+        $this->checker = new SensioLabsSecurityChecker($this->dbDir, 'file://'.$this->repoDir);
     }
 
     protected function tearDown(): void
@@ -124,7 +124,7 @@ final class SensioLabsSecurityCheckerTest extends TestCase
     public function testThrowErrorWhenUpdateFails(): void
     {
         $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage("repository '{$this->repoDir}' does not exist");
+        $this->expectExceptionMessage("'{$this->repoDir}' does not appear to be a git repository");
         $this->checker->update();
     }
 


### PR DESCRIPTION
Hey guys, I stumbled upon a couple of problems while running the tests on docker (with alpine images), so I wanted to make this little change to make tests behavior better on newer versions of git and different linux distros.

Also, the factory method for Config from phpcs has been deprecated, I took time to fix that as well.