### PR TITLE
Make `var/cache` ephemeral

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,7 @@ services:
     sysctls:
       net.core.somaxconn: 2048
     command: >
-      bash -c 'bin/console cache:clear &&
-      bin/console cache:warmup &&
-      bin/console d:m:m --no-interaction &&
+      bash -c 'bin/console d:m:m --no-interaction &&
       bin/console messenger:setup-transports --no-interaction &&
       bin/console repman:security:update-db &&
       bin/console assets:install &&
@@ -32,6 +30,7 @@ services:
     env_file: .env.docker
     volumes:
       - app-var:/app/var
+      - /app/var/cache
       - app-public:/app/public
     depends_on:
       - database
@@ -43,6 +42,7 @@ services:
     env_file: .env.docker
     volumes:
       - app-var:/app/var
+      - /app/var/cache
     depends_on:
       - app
 
@@ -53,6 +53,7 @@ services:
     env_file: .env.docker
     volumes:
       - app-var:/app/var
+      - /app/var/cache
       - docker-crontabs:/var/spool/cron/crontabs
     depends_on:
       - app


### PR DESCRIPTION
Currently whole `var/cache` directory is mounted and shared between 3 containers:

- `app`
- `consumer`
- `cron`

Only `app` is clearing and warming up the cache, but the problem is that there is no guarantee that `app` will actually start and finish clearing cache first before other containers will read it. This may cause issues like: https://github.com/repman-io/repman/issues/417

There is not much need to keep caches / sessions between restarts right now. 

This change overrides `app/var` volume with `/app/var/cache` volume which effectively creates an empty directory in the container on every start. Also I don't see a need for warming up cache for each container.

