### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/Functional/Command/ProxySyncReleasesCommandTest.php
+++ b/tests/Functional/Command/ProxySyncReleasesCommandTest.php
@@ -35,7 +35,7 @@ final class ProxySyncReleasesCommandTest extends FunctionalTestCase
         $commandTester = new CommandTester($command);
         $result = $commandTester->execute([]);
 
-        self::assertTrue(file_exists($newDist));
+        self::assertFileExists($newDist);
         self::assertEquals($result, 0);
         @unlink($newDist);
 
@@ -44,7 +44,7 @@ final class ProxySyncReleasesCommandTest extends FunctionalTestCase
         $commandTester = new CommandTester($command);
         $result = $commandTester->execute([]);
 
-        self::assertFalse(file_exists($newDist));
+        self::assertFileDoesNotExist($newDist);
         self::assertEquals($result, 0);
     }
 
@@ -68,7 +68,7 @@ final class ProxySyncReleasesCommandTest extends FunctionalTestCase
         $commandTester = new CommandTester($command);
         $result = $commandTester->execute([]);
 
-        self::assertFalse(file_exists($newDist));
+        self::assertFileDoesNotExist($newDist);
         self::assertEquals($result, 0);
     }
 

--- a/tests/Functional/Controller/Api/OrganizationControllerTest.php
+++ b/tests/Functional/Controller/Api/OrganizationControllerTest.php
@@ -35,7 +35,7 @@ final class OrganizationControllerTest extends FunctionalTestCase
         self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
 
         $json = $this->jsonResponse();
-        self::assertEquals(count($json['data']), 1);
+        self::assertCount(1, $json['data']);
         self::assertEquals($json['data'][0]['name'], 'Buddy works');
         self::assertEquals($json['data'][0]['alias'], 'buddy-works');
         self::assertEquals($json['data'][0]['hasAnonymousAccess'], false);
@@ -56,7 +56,7 @@ final class OrganizationControllerTest extends FunctionalTestCase
 
         $json = $this->jsonResponse();
 
-        self::assertEquals(count($json['data']), 20);
+        self::assertCount(20, $json['data']);
         self::assertEquals($json['data'][0]['name'], 'test-list-name#27');
         self::assertEquals($json['data'][19]['name'], 'test-list-name#7');
 

--- a/tests/Functional/Controller/Api/PackageControllerTest.php
+++ b/tests/Functional/Controller/Api/PackageControllerTest.php
@@ -146,7 +146,7 @@ final class PackageControllerTest extends FunctionalTestCase
 
         $json = $this->jsonResponse();
 
-        self::assertEquals(count($json['data']), 20);
+        self::assertCount(20, $json['data']);
         self::assertEquals($json['total'], 41);
 
         $baseUrl = $this->urlTo('api_packages', ['organization' => self::$organization], UrlGeneratorInterface::ABSOLUTE_URL);

--- a/tests/Functional/Controller/Api/TokenControllerTest.php
+++ b/tests/Functional/Controller/Api/TokenControllerTest.php
@@ -37,7 +37,7 @@ final class TokenControllerTest extends FunctionalTestCase
         self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
 
         $json = $this->jsonResponse();
-        self::assertEquals(count($json['data']), 1);
+        self::assertCount(1, $json['data']);
         self::assertEquals($json['data'][0]['name'], 'test-list-name');
         self::assertEquals($json['data'][0]['value'], 'test-list-value');
         self::assertNotEmpty($json['data'][0]['createdAt']);
@@ -62,7 +62,7 @@ final class TokenControllerTest extends FunctionalTestCase
 
         $json = $this->jsonResponse();
 
-        self::assertEquals(count($json['data']), 20);
+        self::assertCount(20, $json['data']);
         self::assertEquals($json['data'][0]['name'], 'test-list-name#28');
         self::assertEquals($json['data'][19]['name'], 'test-list-name#8');
 

--- a/tests/Unit/Service/Downloader/ReactDownloaderTest.php
+++ b/tests/Unit/Service/Downloader/ReactDownloaderTest.php
@@ -14,7 +14,7 @@ final class ReactDownloaderTest extends TestCase
     {
         $packages = __DIR__.'/../../../Resources/packages.json';
 
-        self::assertTrue(is_resource((new ReactDownloader())->getContents($packages)->getOrNull()));
+        self::assertIsResource((new ReactDownloader())->getContents($packages)->getOrNull());
     }
 
     public function testFailedDownload(): void


### PR DESCRIPTION
# Changed log

- Using the `assertFileExists` to assert expected file path is existed.
- Using the `assertFileNotExists` to assert expected file path is not existed.
- Using the `assertIsResource` to assert expected type is `resource`.
- Using the `assertCount` to assert expected counter is same as result.
 