### PR TITLE
Make domain separators configurable

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,8 @@
 
 ###> app ###
 APP_HOST=repman.wip
+APP_DOMAIN_SEPARATOR=.
+APP_ORGANIZATION_SEPARATOR=.
 APP_URL_SCHEME=https
 APP_ALLOWED_PACKAGE_TYPES=git,github,gitlab,bitbucket,subversion,mercurial,pear,artifact,path
 APP_GITLAB_API_URL=https://gitlab.com

--- a/.env.docker
+++ b/.env.docker
@@ -19,6 +19,8 @@ PHP_URL=app:9000
 
 ###> app ###
 APP_HOST=repman.wip
+APP_DOMAIN_SEPARATOR=.
+APP_ORGANIZATION_SEPARATOR=.
 APP_URL_SCHEME=https
 APP_ALLOWED_PACKAGE_TYPES=git,github,gitlab,bitbucket,subversion,mercurial,pear,artifact,path
 APP_GITLAB_API_URL=https://gitlab.com

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -14,7 +14,7 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         repo:
-            host: '([a-z0-9_-]+)\%domain_separator%repo\%domain_separator%(.+)'
+            host: '([a-z0-9_-]+)\%organization_separator%repo\%domain_separator%(.+)'
             anonymous: true
             logout: false
             stateless: true
@@ -61,7 +61,7 @@ security:
          - { path: ^/organization/.+/package$, roles: ROLE_ORGANIZATION_ANONYMOUS_USER }
          - { path: ^/organization/.+/package/.+/details$, roles: ROLE_ORGANIZATION_ANONYMOUS_USER }
          - { path: ^/organization/.+(/.+)*, roles: ROLE_ORGANIZATION_MEMBER }
-         - { path: ^/downloads, host: '([a-z0-9_-]+)\%domain_separator%repo\%domain_separator%(.+)', roles: IS_AUTHENTICATED_ANONYMOUSLY}
-         - { path: ^/, host: '([a-z0-9_-]+)\%domain_separator%repo\%domain_separator%(.+)', roles: ROLE_ORGANIZATION }
+         - { path: ^/downloads, host: '([a-z0-9_-]+)\%organization_separator%repo\%domain_separator%(.+)', roles: IS_AUTHENTICATED_ANONYMOUSLY}
+         - { path: ^/, host: '([a-z0-9_-]+)\%organization_separator%repo\%domain_separator%(.+)', roles: ROLE_ORGANIZATION }
          - { path: ^/api/organization/.+(/.+)*, roles: ROLE_ORGANIZATION_MEMBER }
          - { path: ^/api(?!/doc), roles: ROLE_USER }

--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -22,11 +22,11 @@ organization_repo_url:
     host: '{organization}{sep1}repo{sep2}{domain}'
     defaults:
         domain: '%domain%'
-        sep1: '%domain_separator%'
+        sep1: '%organization_separator%'
         sep2: '%domain_separator%'
     requirements:
-        domain: "%domain%"
-        sep1: '%domain_separator%'
+        domain: '%domain%'
+        sep1: '%organization_separator%'
         sep2: '%domain_separator%'
 
 login_github_check:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,7 +7,7 @@ parameters:
     package_name_pattern: '[A-Za-z0-9_.-]+/[A-Za-z0-9_./~-]+?'
     organization_pattern: '[a-z0-9_-]+' # remember to change in security.yaml (access_control)
     domain_separator: '%env(resolve:APP_DOMAIN_SEPARATOR)%' # '-' can be used as alternative for simpler certificate handling in 1 organization self-hosted installs
-    organization_separator: '%env(resolve:APP_ORGANIZATION_SEPARATOR)%' # secondary separator, see organization_repo_url
+    organization_separator: '%env(default:domain_separator:resolve:APP_ORGANIZATION_SEPARATOR)%' # secondary separator, see organization_repo_url
     uuid_pattern: '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
     dists_dir: '%env(resolve:PROXY_DIST_DIR)%'
     repo_dir: '%env(resolve:PACKAGES_DIST_DIR)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,8 @@
 parameters:
     package_name_pattern: '[A-Za-z0-9_.-]+/[A-Za-z0-9_./~-]+?'
     organization_pattern: '[a-z0-9_-]+' # remember to change in security.yaml (access_control)
-    domain_separator: '.' # '-' can be used as alternative for simpler certificate handling in 1 organization self-hosted installs
+    domain_separator: '%env(resolve:APP_DOMAIN_SEPARATOR)%' # '-' can be used as alternative for simpler certificate handling in 1 organization self-hosted installs
+    organization_separator: '%env(resolve:APP_ORGANIZATION_SEPARATOR)%' # secondary separator, see organization_repo_url
     uuid_pattern: '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
     dists_dir: '%env(resolve:PROXY_DIST_DIR)%'
     repo_dir: '%env(resolve:PACKAGES_DIST_DIR)%'

--- a/src/Controller/RepoController.php
+++ b/src/Controller/RepoController.php
@@ -100,8 +100,8 @@ final class RepoController extends AbstractController
      * @Route("/downloads",
      *     name="repo_package_downloads",
      *     host="{organization}{sep1}repo{sep2}{domain}",
-     *     defaults={"domain":"%domain%","sep1"="%domain_separator%","sep2"="%domain_separator%"},
-     *     requirements={"domain"="%domain%","sep1"="%domain_separator%","sep2"="%domain_separator%"},
+     *     defaults={"domain":"%domain%","sep1"="%organization_separator%","sep2"="%domain_separator%"},
+     *     requirements={"domain"="%domain%","sep1"="%organization_separator%","sep2"="%domain_separator%"},
      *     methods={"POST"})
      */
     public function downloads(Request $request, Organization $organization): JsonResponse

--- a/src/Controller/RepoController.php
+++ b/src/Controller/RepoController.php
@@ -32,7 +32,7 @@ final class RepoController extends AbstractController
     }
 
     /**
-     * @Route("/packages.json", host="{organization}{sep1}repo{sep2}{domain}", name="repo_packages", methods={"GET"}, defaults={"domain":"%domain%","sep1"="%domain_separator%","sep2"="%domain_separator%"}, requirements={"domain"="%domain%","sep1"="%domain_separator%","sep2"="%domain_separator%"})
+     * @Route("/packages.json", host="{organization}{sep1}repo{sep2}{domain}", name="repo_packages", methods={"GET"}, defaults={"domain":"%domain%","sep1"="%organization_separator%","sep2"="%domain_separator%"}, requirements={"domain"="%domain%","sep1"="%organization_separator%","sep2"="%domain_separator%"})
      * @Cache(public=false)
      */
     public function packages(Request $request, Organization $organization): JsonResponse
@@ -71,8 +71,8 @@ final class RepoController extends AbstractController
      * @Route("/dists/{package}/{version}/{ref}.{type}",
      *     name="repo_package_dist",
      *     host="{organization}{sep1}repo{sep2}{domain}",
-     *     defaults={"domain":"%domain%","sep1"="%domain_separator%","sep2"="%domain_separator%"},
-     *     requirements={"package"="%package_name_pattern%","ref"="[a-f0-9]*?","type"="zip|tar","domain"="%domain%","sep1"="%domain_separator%","sep2"="%domain_separator%"},
+     *     defaults={"domain":"%domain%","sep1"="%organization_separator%","sep2"="%domain_separator%"},
+     *     requirements={"package"="%package_name_pattern%","ref"="[a-f0-9]*?","type"="zip|tar","domain"="%domain%","sep1"="%organization_separator%","sep2"="%domain_separator%"},
      *     methods={"GET"})
      * @Cache(public=false)
      */
@@ -139,8 +139,8 @@ final class RepoController extends AbstractController
      *      host="{organization}{sep1}repo{sep2}{domain}",
      *      name="repo_package_provider_v2",
      *      methods={"GET"},
-     *      defaults={"domain":"%domain%","sep1"="%domain_separator%","sep2"="%domain_separator%"},
-     *      requirements={"domain"="%domain%","package"="%package_name_pattern%","sep1"="%domain_separator%","sep2"="%domain_separator%"})
+     *      defaults={"domain":"%domain%","sep1"="%organization_separator%","sep2"="%domain_separator%"},
+     *      requirements={"domain"="%domain%","package"="%package_name_pattern%","sep1"="%organization_separator%","sep2"="%domain_separator%"})
      * @Cache(public=false)
      */
     public function providerV2(Request $request, Organization $organization, string $package): JsonResponse


### PR DESCRIPTION
First of all, thanks for your amazing work.
Right now, I'm working on a helm chart to deploy the Repman in the Kubernetes cluster.
Among other things, I want to configure domain separators via environmental variables. 
So this is what this pull request for.