### PR TITLE
Remove trailing slash in nginx volume name docker-logs-nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - app
     volumes:
       - app-public:/app/public
-      - docker-logs-nginx/:/var/log/nginx
+      - docker-logs-nginx:/var/log/nginx
       - docker-nginx-scripts:/nginx
       - docker-nginx-ssl-certs:/etc/ssl/certs
       - docker-nginx-ssl-private:/etc/ssl/private


### PR DESCRIPTION
Fixes #519