### PR TITLE
Feature: Allow custom S3 endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -88,7 +88,7 @@ SECURITY_ADVISORIES_DB_DIR=%kernel.project_dir%/var/security-advisories
 # STORAGE_AWS_OPAQUE_AUTH=false # Either true or false - This will control if you want to use key/secret pair or use machine credentials
 # STORAGE_AWS_KEY=example_key # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_SECRET=example_secret # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
-# STORAGE_AWS_ENDPOINT=s3.myhost.com # This is an optional argument, can be used for self-hosted AWS S3 instances
+# STORAGE_AWS_ENDPOINT="https://s3.myhost.com" # This is an optional argument, can be used for self-hosted AWS S3 instances
 ###< storage ###
 
 ###> excelwebzone/recaptcha-bundle ###

--- a/.env
+++ b/.env
@@ -88,6 +88,7 @@ SECURITY_ADVISORIES_DB_DIR=%kernel.project_dir%/var/security-advisories
 # STORAGE_AWS_OPAQUE_AUTH=false # Either true or false - This will control if you want to use key/secret pair or use machine credentials
 # STORAGE_AWS_KEY=example_key # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_SECRET=example_secret # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
+# STORAGE_AWS_ENDPOINT=s3.myhost.com # This is an optional argument, can be used for self-hosted AWS S3 instances
 ###< storage ###
 
 ###> excelwebzone/recaptcha-bundle ###

--- a/.env.docker
+++ b/.env.docker
@@ -92,6 +92,7 @@ SECURITY_ADVISORIES_DB_DIR=%kernel.project_dir%/var/security-advisories
 # STORAGE_AWS_OPAQUE_AUTH=false # Either true or false - This will control if you want to use key/secret pair or use machine credentials
 # STORAGE_AWS_KEY=example_key # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_SECRET=example_secret # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
+# STORAGE_AWS_ENDPOINT=s3.myhost.com # This is an optional argument, can be used for self-hosted AWS S3 instances
 ###< storage ###
 
 ###> excelwebzone/recaptcha-bundle ###

--- a/.env.docker
+++ b/.env.docker
@@ -92,7 +92,7 @@ SECURITY_ADVISORIES_DB_DIR=%kernel.project_dir%/var/security-advisories
 # STORAGE_AWS_OPAQUE_AUTH=false # Either true or false - This will control if you want to use key/secret pair or use machine credentials
 # STORAGE_AWS_KEY=example_key # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_SECRET=example_secret # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
-# STORAGE_AWS_ENDPOINT=s3.myhost.com # This is an optional argument, can be used for self-hosted AWS S3 instances
+# STORAGE_AWS_ENDPOINT="https://s3.myhost.com" # This is an optional argument, can be used for self-hosted AWS S3 instances
 ###< storage ###
 
 ###> excelwebzone/recaptcha-bundle ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,6 +19,7 @@ parameters:
     security_advisories_db_repo: 'https://github.com/FriendsOfPHP/security-advisories.git'
     instance_id_file: '%kernel.project_dir%/var/instance-id'
     kernel_version: !php/const Buddy\Repman\Kernel::REPMAN_VERSION
+    storage.aws.endpoint: ~
 
 services:
     # default configuration for services in *this* file
@@ -51,7 +52,7 @@ services:
             - '%env(bool:STORAGE_AWS_OPAQUE_AUTH)%'
             - '%env(STORAGE_AWS_KEY)%'
             - '%env(STORAGE_AWS_SECRET)%'
-            - '%env(STORAGE_AWS_ENDPOINT)%'
+            - '%env(default:storage.aws.endpoint:STORAGE_AWS_ENDPOINT)%'
 
     Aws\S3\S3Client:
         lazy: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -51,6 +51,7 @@ services:
             - '%env(bool:STORAGE_AWS_OPAQUE_AUTH)%'
             - '%env(STORAGE_AWS_KEY)%'
             - '%env(STORAGE_AWS_SECRET)%'
+            - '%env(STORAGE_AWS_ENDPOINT)%'
 
     Aws\S3\S3Client:
         lazy: true

--- a/src/Service/Integration/Aws/S3AdapterFactory.php
+++ b/src/Service/Integration/Aws/S3AdapterFactory.php
@@ -18,8 +18,13 @@ final class S3AdapterFactory
 
     private ?string $endpoint;
 
-    public function __construct(string $region, bool $isOpaqueAuth, ?string $key = null, ?string $secret = null, ?string $endpoint = null)
-    {
+    public function __construct(
+        string $region,
+        bool $isOpaqueAuth,
+        ?string $key = null,
+        ?string $secret = null,
+        ?string $endpoint = null
+    ) {
         $this->region = $region;
         $this->isOpaqueAuth = $isOpaqueAuth;
         $this->endpoint = $endpoint;

--- a/src/Service/Integration/Aws/S3AdapterFactory.php
+++ b/src/Service/Integration/Aws/S3AdapterFactory.php
@@ -16,10 +16,13 @@ final class S3AdapterFactory
 
     private string $secret;
 
-    public function __construct(string $region, bool $isOpaqueAuth, ?string $key = null, ?string $secret = null)
+    private ?string $endpoint;
+
+    public function __construct(string $region, bool $isOpaqueAuth, ?string $key = null, ?string $secret = null, ?string $endpoint = null)
     {
         $this->region = $region;
         $this->isOpaqueAuth = $isOpaqueAuth;
+        $this->endpoint = $endpoint;
 
         if ($this->isOpaqueAuth) {
             if ($key === null || $key === '') {
@@ -46,6 +49,10 @@ final class S3AdapterFactory
                 'key' => $this->key,
                 'secret' => $this->secret,
             ];
+        }
+
+        if ($this->endpoint !== null) {
+            $args['endpoint'] = $this->endpoint;
         }
 
         return new S3Client($args);

--- a/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
+++ b/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
@@ -7,6 +7,7 @@ namespace Buddy\Repman\Tests\Unit\Service\Integration\Aws;
 use Aws\Credentials\Credentials;
 use Buddy\Repman\Service\Integration\Aws\S3AdapterFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UriInterface;
 
 class S3AdapterFactoryTest extends TestCase
 {
@@ -35,6 +36,26 @@ class S3AdapterFactoryTest extends TestCase
         $creds = $instance->getCredentials()->wait();
         self::assertSame('mykey', $creds->getAccessKeyId());
         self::assertSame('secret', $creds->getSecretKey());
+    }
+
+    public function testCreateWithoutEndpoint(): void
+    {
+        $factory = new S3AdapterFactory('eu-east-1', true, 'mykey', 'secret');
+
+        $instance = $factory->create();
+        $endpoint = $instance->getEndpoint();
+
+        self::assertSame($endpoint->getHost(), 's3.eu-east-1.amazonaws.com');
+    }
+
+    public function testCreateWithEndpoint(): void
+    {
+        $factory = new S3AdapterFactory('eu-east-1', true, 'mykey', 'secret', 'https://s3.example.com');
+
+        $instance = $factory->create();
+        $endpoint = $instance->getEndpoint();
+
+        self::assertSame($endpoint->getHost(), 's3.example.com');
     }
 
     /**

--- a/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
+++ b/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
@@ -7,7 +7,6 @@ namespace Buddy\Repman\Tests\Unit\Service\Integration\Aws;
 use Aws\Credentials\Credentials;
 use Buddy\Repman\Service\Integration\Aws\S3AdapterFactory;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\UriInterface;
 
 class S3AdapterFactoryTest extends TestCase
 {
@@ -50,7 +49,13 @@ class S3AdapterFactoryTest extends TestCase
 
     public function testCreateWithEndpoint(): void
     {
-        $factory = new S3AdapterFactory('eu-east-1', true, 'mykey', 'secret', 'https://s3.example.com');
+        $factory = new S3AdapterFactory(
+            'eu-east-1',
+            true,
+            'mykey',
+            'secret',
+            'https://s3.example.com'
+        );
 
         $instance = $factory->create();
         $endpoint = $instance->getEndpoint();


### PR DESCRIPTION
Allow a custom S3 endpoint, used when not using AWS but a different S3 provider that is AWS compatible.