### PR TITLE
Support redis symfony/messenger consumers

### DIFF
--- a/.env
+++ b/.env
@@ -41,8 +41,11 @@ DATABASE_URL=postgresql://127.0.0.1:5432/main?serverVersion=11&charset=utf8
 ###> symfony/messenger ###
 # Choose one of the transports below
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=doctrine://default
+# MESSENGER_TRANSPORT_FAILED_DSN=amqp://guest:guest@localhost:5672/%2f/failed
+MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=false
+MESSENGER_TRANSPORT_FAILED_DSN=doctrine://default?queue_name=failed&auto_setup=false
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+# MESSENGER_TRANSPORT_FAILED_DSN=redis://localhost:6379/failed
 ###< symfony/messenger ###
 
 ###> symfony/mailer ###

--- a/.env.docker
+++ b/.env.docker
@@ -45,8 +45,11 @@ DATABASE_URL=postgresql://main:main@database:5432/main?serverVersion=11&charset=
 ###> symfony/messenger ###
 # Choose one of the transports below
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=doctrine://default
+# MESSENGER_TRANSPORT_FAILED_DSN=amqp://guest:guest@localhost:5672/%2f/failed
+MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=false
+MESSENGER_TRANSPORT_FAILED_DSN=doctrine://default?queue_name=failed&auto_setup=false
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+# MESSENGER_TRANSPORT_FAILED_DSN=redis://localhost:6379/failed
 ###< symfony/messenger ###
 
 ###> symfony/mailer ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TIMEZONE="UTC"
 
 SHELL ["sh", "-eo", "pipefail", "-c"]
 
-# install composer and extensions: pdo_pgsql, intl, zip
+# install composer and extensions: pdo_pgsql, redis, intl, zip
 RUN apk update && \
     apk add --no-cache -q \
     $PHPIZE_DEPS \
@@ -17,6 +17,8 @@ RUN apk update && \
     icu-dev \
     libzip-dev \
     openssh-client \
+    && pecl install \
+    redis \
     && \
     curl -sS https://getcomposer.org/installer | \
     php -- --install-dir=/usr/local/bin --filename=composer && \
@@ -26,6 +28,7 @@ RUN apk update && \
     docker-php-ext-install pdo_pgsql && \
     docker-php-ext-install intl && \
     docker-php-ext-install zip && \
+    docker-php-ext-enable redis.so && \
     rm -rf /var/cache/apk/*
 
 # set timezone

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "symfony/messenger": "5.3.*",
         "symfony/monolog-bundle": "^3.5",
         "symfony/process": "5.3.*",
+        "symfony/redis-messenger": "5.3.*",
         "symfony/security-bundle": "5.3.*",
         "symfony/twig-bundle": "5.3.*",
         "symfony/validator": "5.3.*",
@@ -113,7 +114,12 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "phpstan/extension-installer": true,
+            "symfony/flex": true
+        }
     },
     "extra": {
         "symfony": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7631696c61c53f4b9bb71444acb03d6e",
+    "content-hash": "c3d383497c2cadc746746951f9d06538",
     "packages": [
         {
             "name": "async-aws/core",
@@ -11770,16 +11770,16 @@
         },
         {
             "name": "symfony/redis-messenger",
-            "version": "v5.3.10",
+            "version": "v5.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/redis-messenger.git",
-                "reference": "94ba9b20a7f2b28ec9e93823d7912ced0108b398"
+                "reference": "56626720a8802ca3bb8303f5ba2115bde21dec74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/redis-messenger/zipball/94ba9b20a7f2b28ec9e93823d7912ced0108b398",
-                "reference": "94ba9b20a7f2b28ec9e93823d7912ced0108b398",
+                "url": "https://api.github.com/repos/symfony/redis-messenger/zipball/56626720a8802ca3bb8303f5ba2115bde21dec74",
+                "reference": "56626720a8802ca3bb8303f5ba2115bde21dec74",
                 "shasum": "",
                 "mirrors": [
                     {
@@ -11823,7 +11823,7 @@
             "description": "Symfony Redis extension Messenger Bridge",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/redis-messenger/tree/v5.3.10"
+                "source": "https://github.com/symfony/redis-messenger/tree/v5.3.13"
             },
             "funding": [
                 {
@@ -11839,7 +11839,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-25T14:58:02+00:00"
+            "time": "2021-12-28T17:08:14+00:00"
         },
         {
             "name": "symfony/routing",
@@ -17318,5 +17318,5 @@
         "ext-zip": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -8,8 +8,8 @@ framework:
         failure_transport: failed
 
         transports:
-            async: 'doctrine://default?auto_setup=false'
-            failed: 'doctrine://default?queue_name=failed&auto_setup=false'
+            async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            failed: '%env(MESSENGER_TRANSPORT_FAILED_DSN)%'
 
         routing:
             'Buddy\Repman\Message\Organization\SynchronizePackage': async

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
+  redis:
+    << : *restart_policy
+    image: redis:6.2-alpine
+
   app:
     << : *restart_policy
     image: buddy/repman:1.3.4
@@ -34,6 +38,7 @@ services:
       - app-public:/app/public
     depends_on:
       - database
+      - redis
 
   consumer:
     << : *restart_policy

--- a/src/Service/Telemetry.php
+++ b/src/Service/Telemetry.php
@@ -17,6 +17,7 @@ use Buddy\Repman\Service\Telemetry\Entry\Proxy;
 use Buddy\Repman\Service\Telemetry\TechnicalEmail;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
 
 final class Telemetry
 {
@@ -24,10 +25,10 @@ final class Telemetry
     private TelemetryQuery $query;
     private Endpoint $endpoint;
     private Config $config;
-    private MessageCountAwareInterface $failedTransport;
+    private TransportInterface $failedTransport;
     private ProxyRegister $proxies;
 
-    public function __construct(string $instanceIdFile, TelemetryQuery $query, Endpoint $endpoint, Config $config, MessageCountAwareInterface $failedTransport, ProxyRegister $proxies)
+    public function __construct(string $instanceIdFile, TelemetryQuery $query, Endpoint $endpoint, Config $config, TransportInterface $failedTransport, ProxyRegister $proxies)
     {
         $this->instanceIdFile = $instanceIdFile;
         $this->query = $query;
@@ -70,7 +71,7 @@ final class Telemetry
                     sprintf('%s %s', php_uname('s'), php_uname('r')),
                     PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION,
                     $this->query->usersCount(),
-                    $this->failedTransport->getMessageCount(),
+                    ($this->failedTransport instanceof MessageCountAwareInterface) ? $this->failedTransport->getMessageCount() : 0,
                     $this->getConfig(),
                 ),
                 $this->getOrganizations($date),


### PR DESCRIPTION
The pull requests adds support for using the symfony/messenger redis consumers. The default is still the doctrine but overriding the MESSENGER_TRANSPORT_* env variables allows users to switch to redis.

Initial testing indicates no problems but not finished yet.

Fixes https://github.com/repman-io/repman/issues/533

p.s. The added `allowed-plugins` in the composer.json is part of composer 2.2. Read more about it in the [release post](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution)