### PR TITLE
Feature: Synchronise all packages command

### DIFF
--- a/src/Command/SynchronizeAllPackagesCommand.php
+++ b/src/Command/SynchronizeAllPackagesCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Command;
+
+use Buddy\Repman\Entity\Organization;
+use Buddy\Repman\Entity\Organization\Package;
+use Buddy\Repman\Message\Organization\SynchronizePackage;
+use Buddy\Repman\Repository\OrganizationRepository;
+use Buddy\Repman\Repository\PackageRepository;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class SynchronizeAllPackagesCommand extends Command
+{
+    protected static $defaultName = 'repman:package:synchronize-all';
+
+    private MessageBusInterface $bus;
+
+    private OrganizationRepository $organizations;
+
+    public function __construct(MessageBusInterface $bus, OrganizationRepository $organizations)
+    {
+        $this->bus = $bus;
+        $this->organizations = $organizations;
+
+        parent::__construct();
+    }
+
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription('Synchronize all packages')
+            ->addArgument('organization', InputArgument::OPTIONAL, 'Organization alias')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $organizations = $this->getOrganizationsToSync($input->getArgument('organization'));
+        $output->writeln(sprintf('Synchronizing packages of %d organizations.', count($organizations)));
+
+        foreach ($organizations as $organization) {
+            $output->writeln(sprintf('Synchronizing packages for %s.', $organization->name()));
+
+            foreach ($organization->synchronizedPackages() as $package) {
+                $output->writeln(sprintf('- %s.', $package->name()));
+                $this->bus->dispatch(new SynchronizePackage($package->id()->toString()));
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param string|null $organizationAlias
+     * @return Organization[]
+     */
+    protected function getOrganizationsToSync(?string $organizationAlias): array
+    {
+        if ($organizationAlias === null) {
+            return $this->organizations->findAll();
+        }
+
+        $organization = $this->organizations->findOneBy(['alias' => $organizationAlias]);
+
+        if (!$organization instanceof Organization) {
+            throw new \InvalidArgumentException(sprintf('Organization with alias %s not found.', $organizationAlias));
+        }
+
+        return [$organization];
+    }
+}

--- a/src/Command/SynchronizeAllPackagesCommand.php
+++ b/src/Command/SynchronizeAllPackagesCommand.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Buddy\Repman\Command;
 
 use Buddy\Repman\Entity\Organization;
-use Buddy\Repman\Entity\Organization\Package;
 use Buddy\Repman\Message\Organization\SynchronizePackage;
 use Buddy\Repman\Repository\OrganizationRepository;
-use Buddy\Repman\Repository\PackageRepository;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -61,7 +58,6 @@ final class SynchronizeAllPackagesCommand extends Command
     }
 
     /**
-     * @param string|null $organizationAlias
      * @return Organization[]
      */
     protected function getOrganizationsToSync(?string $organizationAlias): array

--- a/tests/Functional/Command/SynchronizeAllPackagesCommandTest.php
+++ b/tests/Functional/Command/SynchronizeAllPackagesCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Tests\Functional\Command;
+
+use Buddy\Repman\Command\SynchronizeAllPackagesCommand;
+use Buddy\Repman\Message\Security\ScanPackage;
+use Buddy\Repman\Tests\Functional\FunctionalTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemoryTransport;
+
+final class SynchronizeAllPackagesCommandTest extends FunctionalTestCase
+{
+    private string $buddyId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $userId = $this->createAndLoginAdmin();
+        $this->buddyId = $this->fixtures->createOrganization('buddy', $userId);
+
+        $packageId = $this->fixtures->addPackage($this->buddyId, 'https://buddy.com');
+        $this->fixtures->syncPackageWithData($packageId, 'buddy-works/buddy', 'Test', '1.1.1', new \DateTimeImmutable());
+    }
+
+    public function testSynchronizeAllSuccess(): void
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = $this->container()->get('messenger.transport.async');
+        $transport->reset();
+
+        $commandTester = new CommandTester($this->container()->get(SynchronizeAllPackagesCommand::class));
+        $result = $commandTester->execute([]);
+
+        self::assertCount(1, $transport->getSent());
+        self::assertInstanceOf(ScanPackage::class, $transport->getSent()[0]->getMessage());
+        self::assertEquals($result, 0);
+    }
+
+    public function testSynchronizeAllOrganizationSuccess(): void
+    {
+        $alias = 'buddy';
+        /** @var InMemoryTransport $transport */
+        $transport = $this->container()->get('messenger.transport.async');
+        $transport->reset();
+
+        $commandTester = new CommandTester($this->container()->get(SynchronizeAllPackagesCommand::class));
+        $result = $commandTester->execute(['organization' => $alias]);
+
+        self::assertCount(1, $transport->getSent());
+        self::assertInstanceOf(ScanPackage::class, $transport->getSent()[0]->getMessage());
+        self::assertEquals($result, 0);
+    }
+
+    public function testSynchronizeAllOrganizationFailure(): void
+    {
+        $alias = 'non-existing-alias';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Organization with alias %s not found.', $alias));
+
+        /** @var InMemoryTransport $transport */
+        $transport = $this->container()->get('messenger.transport.async');
+        $transport->reset();
+
+        $commandTester = new CommandTester($this->container()->get(SynchronizeAllPackagesCommand::class));
+        $commandTester->execute(['organization' => $alias]);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to sync all packages at once. We currently have the need for this sometimes and are already able to do this manually through the API. However, it's much easier if this is an out-of-the-box CLI feature. 

You can specify to sync all packages from an Organization, or just go through all Organizations and sync their packages. 

Can be called like:
```bash
# Synchronise all packages from the "buddy" Organization
$ ./bin/console repman:package:synchronize-all buddy

# Synchronise all packages from all available Organizations
$ ./bin/console repman:package:synchronize-all
Synchronizing packages of 2 organizations.
Synchronizing packages for test.
- xvilo/harvest-forceast
Synchronizing packages for buddy.
- cache/filesystem-adapter
- symfony/var-dumper
- symfony/translation
- symfony/routing
```

Will throw an InvalidArgumentException if the supplied Organization Alias can not be found.