### PR TITLE
Fix detection of latest stable release (fix #443)

### DIFF
--- a/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
+++ b/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
@@ -79,6 +79,13 @@ final class ComposerPackageSynchronizer implements PackageSynchronizer
             $latest = current($packages);
 
             foreach ($packages as $p) {
+                if ($p->getStability() === Version::STABILITY_STABLE) {
+                    $latest = $p;
+                    break;
+                }
+            }
+
+            foreach ($packages as $p) {
                 $json['packages'][$p->getPrettyName()][$p->getPrettyVersion()] = $this->packageNormalizer->normalize($p);
                 if (Comparator::greaterThan($p->getVersion(), $latest->getVersion()) && $p->getStability() === Version::STABILITY_STABLE) {
                     $latest = $p;


### PR DESCRIPTION
If the first fetched package is not stable, but has a greater version than any of the stable packages, wrong behaviors such as that reported in #443 may occur.