### PR TITLE
Truncate overly long `suggest` fields before persisting them

### DIFF
--- a/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
+++ b/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
@@ -173,7 +173,7 @@ final class ComposerPackageSynchronizer implements PackageSynchronizer
                     // suggests are different
                     foreach ($latest->getSuggests() as $linkName => $linkDescription) {
                         if (\mb_strlen($linkDescription) > 255) {
-                            $linkDescription = \mb_substr($linkDescription, 0, 250) . ' [..]';
+                            $linkDescription = \mb_substr($linkDescription, 0, 250).' [..]';
                         }
 
                         $package->addLink(new Link(Uuid::uuid4(), $package, 'suggests', $linkName, $linkDescription));

--- a/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
+++ b/src/Service/PackageSynchronizer/ComposerPackageSynchronizer.php
@@ -172,6 +172,10 @@ final class ComposerPackageSynchronizer implements PackageSynchronizer
 
                     // suggests are different
                     foreach ($latest->getSuggests() as $linkName => $linkDescription) {
+                        if (\mb_strlen($linkDescription) > 255) {
+                            $linkDescription = \mb_substr($linkDescription, 0, 250) . ' [..]';
+                        }
+
                         $package->addLink(new Link(Uuid::uuid4(), $package, 'suggests', $linkName, $linkDescription));
                         $encounteredLinks['suggests-'.$linkName] = true;
                     }


### PR DESCRIPTION
The `constraint` field from the `organization_package_link` table is limited to 255 chars.

Currently, synchronization fails for packages that use `suggest` fields longer than 255 chars, and it becomes impossible to manage them from the UI (even if only to remove them).

Note that I am open to suggestions on how we might otherwise handle these cases.