### PR TITLE
Introduce org setting enable_security_scan

### DIFF
--- a/src/Controller/Organization/PackageController.php
+++ b/src/Controller/Organization/PackageController.php
@@ -209,7 +209,8 @@ final class PackageController extends AbstractController
                 $form->get('url')->getData(),
                 in_array($type, ['git', 'mercurial', 'subversion'], true) ? 'vcs' : $type,
                 [],
-                $form->get('keepLastReleases')->getData()
+                $form->get('keepLastReleases')->getData(),
+                $organization->isSecurityScanEnabled()
             ));
             $this->messageBus->dispatch(new SynchronizePackage($id));
 
@@ -238,7 +239,8 @@ final class PackageController extends AbstractController
                     "https://github.com/{$repo}",
                     'github-oauth',
                     [Metadata::GITHUB_REPO_NAME => $repo],
-                    $form->get('keepLastReleases')->getData()
+                    $form->get('keepLastReleases')->getData(),
+                    $organization->isSecurityScanEnabled()
                 ));
                 $this->messageBus->dispatch(new SynchronizePackage($id));
                 $this->messageBus->dispatch(new AddGitHubHook($id));
@@ -269,7 +271,8 @@ final class PackageController extends AbstractController
                     $projects->get($projectId)->url(),
                     'gitlab-oauth',
                     [Metadata::GITLAB_PROJECT_ID => $projectId],
-                    $form->get('keepLastReleases')->getData()
+                    $form->get('keepLastReleases')->getData(),
+                    $organization->isSecurityScanEnabled()
                 ));
                 $this->messageBus->dispatch(new SynchronizePackage($id));
                 $this->messageBus->dispatch(new AddGitLabHook($id));
@@ -300,7 +303,8 @@ final class PackageController extends AbstractController
                     $repos->get($repoUuid)->url(),
                     'bitbucket-oauth',
                     [Metadata::BITBUCKET_REPO_NAME => $repos->get($repoUuid)->name()],
-                    $form->get('keepLastReleases')->getData()
+                    $form->get('keepLastReleases')->getData(),
+                    $organization->isSecurityScanEnabled()
                 ));
                 $this->messageBus->dispatch(new SynchronizePackage($id));
                 $this->messageBus->dispatch(new AddBitbucketHook($id));

--- a/src/Controller/OrganizationController.php
+++ b/src/Controller/OrganizationController.php
@@ -7,10 +7,12 @@ namespace Buddy\Repman\Controller;
 use Buddy\Repman\Form\Type\Organization\ChangeAliasType;
 use Buddy\Repman\Form\Type\Organization\ChangeAnonymousAccessType;
 use Buddy\Repman\Form\Type\Organization\ChangeNameType;
+use Buddy\Repman\Form\Type\Organization\EnableSecurityScanType;
 use Buddy\Repman\Form\Type\Organization\GenerateTokenType;
 use Buddy\Repman\Message\Organization\ChangeAlias;
 use Buddy\Repman\Message\Organization\ChangeAnonymousAccess;
 use Buddy\Repman\Message\Organization\ChangeName;
+use Buddy\Repman\Message\Organization\EnableSecurityScan;
 use Buddy\Repman\Message\Organization\GenerateToken;
 use Buddy\Repman\Message\Organization\Package\AddBitbucketHook;
 use Buddy\Repman\Message\Organization\Package\AddGitHubHook;
@@ -290,11 +292,21 @@ final class OrganizationController extends AbstractController
             return $this->redirectToRoute('organization_settings', ['organization' => $organization->alias()]);
         }
 
+        $enableSecurityScanForm = $this->createForm(EnableSecurityScanType::class, ['isSecurityScanEnabled' => $organization->isSecurityScanEnabled()]);
+        $enableSecurityScanForm->handleRequest($request);
+        if ($enableSecurityScanForm->isSubmitted() && $enableSecurityScanForm->isValid()) {
+            $this->messageBus->dispatch(new EnableSecurityScan($organization->id(), $enableSecurityScanForm->get('isSecurityScanEnabled')->getData()));
+            $this->addFlash('success', 'Default package security scans have been successfully changed.');
+
+            return $this->redirectToRoute('organization_settings', ['organization' => $organization->alias()]);
+        }
+
         return $this->render('organization/settings.html.twig', [
             'organization' => $organization,
             'renameForm' => $renameForm->createView(),
             'aliasForm' => $aliasForm->createView(),
             'anonymousAccessForm' => $anonymousAccessForm->createView(),
+            'enableSecurityScanForm' => $enableSecurityScanForm->createView(),
         ]);
     }
 

--- a/src/Entity/Organization.php
+++ b/src/Entity/Organization.php
@@ -70,6 +70,11 @@ class Organization
      */
     private bool $hasAnonymousAccess = false;
 
+    /**
+     * @ORM\Column(type="boolean", options={"default": true})
+     */
+    private bool $enable_security_scan = true;
+
     public function __construct(UuidInterface $id, User $owner, string $name, string $alias)
     {
         $this->id = $id;
@@ -254,6 +259,11 @@ class Organization
     public function changeAnonymousAccess(bool $hasAnonymousAccess): void
     {
         $this->hasAnonymousAccess = $hasAnonymousAccess;
+    }
+
+    public function enableSecurityScan(bool $enableSecurityScan): void
+    {
+        $this->enable_security_scan = $enableSecurityScan;
     }
 
     private function isLastOwner(User $user): bool

--- a/src/Form/Type/Organization/EnableSecurityScanType.php
+++ b/src/Form/Type/Organization/EnableSecurityScanType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Form\Type\Organization;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class EnableSecurityScanType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return '';
+    }
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('isSecurityScanEnabled', ChoiceType::class, [
+                'choices' => [
+                    'Enable' => true,
+                    'Disable' => false,
+                ],
+                'label' => 'Enable security scan for new packages',
+                'required' => true,
+            ])
+            ->add('enableSecurityScan', SubmitType::class, ['label' => 'Change'])
+        ;
+    }
+}

--- a/src/Message/Organization/AddPackage.php
+++ b/src/Message/Organization/AddPackage.php
@@ -11,6 +11,7 @@ final class AddPackage
     private string $type;
     private string $organizationId;
     private int $keepLastReleases;
+    private bool $enableSecurityScan;
 
     /**
      * @var mixed[]
@@ -20,7 +21,7 @@ final class AddPackage
     /**
      * @param mixed[] $metadata
      */
-    public function __construct(string $id, string $organizationId, string $url, string $type = 'vcs', array $metadata = [], ?int $keepLastReleases = null)
+    public function __construct(string $id, string $organizationId, string $url, string $type = 'vcs', array $metadata = [], ?int $keepLastReleases = null, bool $enableSecurityScan = true)
     {
         $this->id = $id;
         $this->organizationId = $organizationId;
@@ -28,6 +29,7 @@ final class AddPackage
         $this->type = $type;
         $this->metadata = $metadata;
         $this->keepLastReleases = $keepLastReleases ?? 0;
+        $this->enableSecurityScan = $enableSecurityScan;
     }
 
     public function id(): string
@@ -61,5 +63,10 @@ final class AddPackage
     public function keepLastReleases(): int
     {
         return $this->keepLastReleases;
+    }
+
+    public function hasSecurityScanEnabled(): bool
+    {
+        return $this->enableSecurityScan;
     }
 }

--- a/src/Message/Organization/EnableSecurityScan.php
+++ b/src/Message/Organization/EnableSecurityScan.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Message\Organization;
+
+final class EnableSecurityScan
+{
+    private string $organizationId;
+    private bool $enableSecurityScan;
+
+    public function __construct(string $organizationId, bool $enableSecurityScan)
+    {
+        $this->organizationId = $organizationId;
+        $this->enableSecurityScan = $enableSecurityScan;
+    }
+
+    public function organizationId(): string
+    {
+        return $this->organizationId;
+    }
+
+    public function hasSecurityScanEnabled(): bool
+    {
+        return $this->enableSecurityScan;
+    }
+}

--- a/src/MessageHandler/Organization/AddPackageHandler.php
+++ b/src/MessageHandler/Organization/AddPackageHandler.php
@@ -29,7 +29,8 @@ final class AddPackageHandler implements MessageHandlerInterface
                     $message->type(),
                     $message->url(),
                     $message->metadata(),
-                    $message->keepLastReleases()
+                    $message->keepLastReleases(),
+                    $message->hasSecurityScanEnabled()
                 )
             )
         ;

--- a/src/MessageHandler/Organization/EnableSecurityScanHandler.php
+++ b/src/MessageHandler/Organization/EnableSecurityScanHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\MessageHandler\Organization;
+
+use Buddy\Repman\Message\Organization\EnableSecurityScan;
+use Buddy\Repman\Repository\OrganizationRepository;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+final class EnableSecurityScanHandler implements MessageHandlerInterface
+{
+    private OrganizationRepository $repositories;
+
+    public function __construct(OrganizationRepository $repositories)
+    {
+        $this->repositories = $repositories;
+    }
+
+    public function __invoke(EnableSecurityScan $message): void
+    {
+        $this->repositories
+            ->getById(Uuid::fromString($message->organizationId()))
+            ->enableSecurityScan($message->hasSecurityScanEnabled())
+        ;
+    }
+}

--- a/src/Migrations/Version20220520191545.php
+++ b/src/Migrations/Version20220520191545.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220520191545 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE organization ADD enable_security_scan BOOLEAN DEFAULT \'true\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE organization DROP enable_security_scan');
+    }
+}

--- a/src/Query/Api/Model/Organization.php
+++ b/src/Query/Api/Model/Organization.php
@@ -10,13 +10,15 @@ final class Organization implements \JsonSerializable
     private string $name;
     private string $alias;
     private bool $hasAnonymousAccess;
+    private bool $enableSecurityScan;
 
-    public function __construct(string $id, string $name, string $alias, bool $hasAnonymousAccess)
+    public function __construct(string $id, string $name, string $alias, bool $hasAnonymousAccess, bool $enableSecurityScan)
     {
         $this->id = $id;
         $this->name = $name;
         $this->alias = $alias;
         $this->hasAnonymousAccess = $hasAnonymousAccess;
+        $this->enableSecurityScan = $enableSecurityScan;
     }
 
     public function getId(): string
@@ -39,6 +41,11 @@ final class Organization implements \JsonSerializable
         return $this->hasAnonymousAccess;
     }
 
+    public function getEnabledSecurityScan(): bool
+    {
+        return $this->enableSecurityScan;
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -49,6 +56,7 @@ final class Organization implements \JsonSerializable
             'name' => $this->getName(),
             'alias' => $this->getAlias(),
             'hasAnonymousAccess' => $this->getHasAnonymousAccess(),
+            'enabledSecurityScan' => $this->enableSecurityScan,
         ];
     }
 }

--- a/src/Query/Api/OrganizationQuery/DbalOrganizationQuery.php
+++ b/src/Query/Api/OrganizationQuery/DbalOrganizationQuery.php
@@ -25,7 +25,7 @@ final class DbalOrganizationQuery implements OrganizationQuery
     public function getById(string $id): Option
     {
         $data = $this->connection->fetchAssociative(
-            'SELECT id, name, alias, has_anonymous_access
+            'SELECT id, name, alias, has_anonymous_access, enable_security_scan
             FROM "organization" WHERE id = :id', [
             'id' => $id,
         ]);
@@ -41,7 +41,7 @@ final class DbalOrganizationQuery implements OrganizationQuery
         return array_map(function (array $data): Organization {
             return $this->hydrateOrganization($data);
         }, $this->connection->fetchAllAssociative(
-            'SELECT o.id, o.name, o.alias, om.role, o.has_anonymous_access
+            'SELECT o.id, o.name, o.alias, om.role, o.has_anonymous_access, o.enable_security_scan
             FROM organization_member om
             JOIN organization o ON o.id = om.organization_id
             WHERE om.user_id = :userId
@@ -143,6 +143,7 @@ final class DbalOrganizationQuery implements OrganizationQuery
             $data['name'],
             $data['alias'],
             $data['has_anonymous_access'],
+            $data['enable_security_scan'],
         );
     }
 

--- a/src/Query/User/Model/Organization.php
+++ b/src/Query/User/Model/Organization.php
@@ -13,6 +13,7 @@ final class Organization
     private string $name;
     private string $alias;
     private bool $hasAnonymousAccess;
+    private bool $enableSecurityScan;
 
     /**
      * @var Member[]
@@ -22,13 +23,14 @@ final class Organization
     /**
      * @param Member[] $members
      */
-    public function __construct(string $id, string $name, string $alias, array $members, bool $hasAnonymousAccess)
+    public function __construct(string $id, string $name, string $alias, array $members, bool $hasAnonymousAccess, bool $enableSecurityScan)
     {
         $this->id = $id;
         $this->name = $name;
         $this->alias = $alias;
         $this->members = array_map(fn (Member $member) => $member, $members);
         $this->hasAnonymousAccess = $hasAnonymousAccess;
+        $this->enableSecurityScan = $enableSecurityScan;
     }
 
     public function id(): string
@@ -92,5 +94,10 @@ final class Organization
     public function hasAnonymousAccess(): bool
     {
         return $this->hasAnonymousAccess;
+    }
+
+    public function isSecurityScanEnabled(): bool
+    {
+        return $this->enableSecurityScan;
     }
 }

--- a/src/Query/User/OrganizationQuery/DbalOrganizationQuery.php
+++ b/src/Query/User/OrganizationQuery/DbalOrganizationQuery.php
@@ -29,7 +29,7 @@ final class DbalOrganizationQuery implements OrganizationQuery
     public function getByAlias(string $alias): Option
     {
         $data = $this->connection->fetchAssociative(
-            'SELECT id, name, alias, has_anonymous_access
+            'SELECT id, name, alias, has_anonymous_access, enable_security_scan
             FROM "organization" WHERE alias = :alias', [
             'alias' => $alias,
         ]);
@@ -44,7 +44,7 @@ final class DbalOrganizationQuery implements OrganizationQuery
     public function getByInvitation(string $token, string $email): Option
     {
         $data = $this->connection->fetchAssociative(
-            'SELECT o.id, o.name, o.alias, o.has_anonymous_access
+            'SELECT o.id, o.name, o.alias, o.has_anonymous_access, o.enable_security_scan
             FROM "organization" o
             JOIN organization_invitation i ON o.id = i.organization_id
             WHERE i.token = :token AND i.email = :email
@@ -240,6 +240,7 @@ final class DbalOrganizationQuery implements OrganizationQuery
             $data['alias'],
             array_map(fn (array $row) => new Member($row['user_id'], $row['email'], $row['role']), $members),
             $data['has_anonymous_access'],
+            $data['enable_security_scan'],
         );
     }
 

--- a/templates/organization/settings.html.twig
+++ b/templates/organization/settings.html.twig
@@ -47,6 +47,21 @@
         {{ form_end(anonymousAccessForm) }}
     <hr />
 
+    <h4>Package Security scan</h4>
+    <p>
+        Enabling or disable the security scan for new packages. Changing this setting will not affect existing packages!
+    </p>
+    {{ form_start(enableSecurityScanForm, {attr:{class:'row'}}) }}
+    <div class="col-4">
+        {{ form_widget(enableSecurityScanForm.isSecurityScanEnabled) }}
+        {{ form_errors(enableSecurityScanForm.isSecurityScanEnabled) }}
+    </div>
+    <div class="col-4 text-right">
+        {{ form_widget(enableSecurityScanForm.enableSecurityScan, {attr:{class:'btn-danger'}}) }}
+    </div>
+    {{ form_end(enableSecurityScanForm) }}
+    <hr />
+
     <h4>Delete this organization</h4>
     <div class="row">
         <div class="col-6">

--- a/tests/Functional/Controller/Api/OrganizationControllerTest.php
+++ b/tests/Functional/Controller/Api/OrganizationControllerTest.php
@@ -39,6 +39,7 @@ final class OrganizationControllerTest extends FunctionalTestCase
         self::assertEquals($json['data'][0]['name'], 'Buddy works');
         self::assertEquals($json['data'][0]['alias'], 'buddy-works');
         self::assertEquals($json['data'][0]['hasAnonymousAccess'], false);
+        self::assertEquals($json['data'][0]['enabledSecurityScan'], true);
         self::assertEquals($json['total'], 1);
         self::assertNotEmpty($json['links']);
     }
@@ -83,6 +84,7 @@ final class OrganizationControllerTest extends FunctionalTestCase
         self::assertEquals($json['name'], 'New organization');
         self::assertEquals($json['alias'], 'new-organization');
         self::assertEquals($json['hasAnonymousAccess'], false);
+        self::assertEquals($json['enabledSecurityScan'], true);
         self::assertFalse(
             $this->container()
                 ->get(DbalOrganizationQuery::class)

--- a/tests/Functional/Controller/OrganizationControllerTest.php
+++ b/tests/Functional/Controller/OrganizationControllerTest.php
@@ -750,6 +750,35 @@ final class OrganizationControllerTest extends FunctionalTestCase
         self::assertStringContainsString('Anonymous access has been successfully changed.', $this->lastResponseBody());
     }
 
+    public function testChangeEnableSecurityScan(): void
+    {
+        $this->fixtures->createOrganization('buddy', $this->userId);
+        $this->client->followRedirects();
+
+        $organization = $this
+            ->container()
+            ->get(DbalOrganizationQuery::class)
+            ->getByAlias('buddy')
+            ->get();
+
+        self::assertTrue($organization->isSecurityScanEnabled());
+
+        $this->client->request('GET', $this->urlTo('organization_settings', ['organization' => 'buddy']));
+        $this->client->submitForm('enableSecurityScan', [
+            'isSecurityScanEnabled' => 0,
+        ]);
+
+        $organization = $this
+            ->container()
+            ->get(DbalOrganizationQuery::class)
+            ->getByAlias('buddy')
+            ->get();
+
+        self::assertFalse($organization->isSecurityScanEnabled());
+        self::assertTrue($this->client->getResponse()->isOk());
+        self::assertStringContainsString('Default package security scans have been successfully changed.', $this->lastResponseBody());
+    }
+
     public function testRemoveOrganization(): void
     {
         $organizationId = $this->fixtures->createOrganization('buddy inc', $this->userId);

--- a/tests/MotherObject/Query/OrganizationMother.php
+++ b/tests/MotherObject/Query/OrganizationMother.php
@@ -16,7 +16,8 @@ final class OrganizationMother
             'Repman',
             'repman',
             [new Organization\Member('5c1b8e35-fe7b-4418-b722-ec9cbbf2598a', 'test@repman.io', 'owner')],
-            false
+            false,
+            true
         );
     }
 
@@ -27,7 +28,8 @@ final class OrganizationMother
             'Repman',
             'repman',
             [$member],
-            false
+            false,
+            true
         );
     }
 }


### PR DESCRIPTION
As discussed in #575 introduce a setting for the organization to define the default for new packages.

When a new organization is created the default value for the `enable_security_scan` configuration is true to stick to the previous defaults. The setting can be changed afterward in the respective form like this:
![scan](https://user-images.githubusercontent.com/596449/169642219-3ef4fc1a-e370-4792-b717-0a23b4cd4afc.png)

When a new package is created the default value for `enable_security_scan` flag on the package level is set to the value defined in the organization settings.

As you can see in the screenshot above, changing the setting on the organization level does not change the settings for all packages of that organization. It just will change the default value for newly created packages.