### PR TITLE
Fix Git default branch

### DIFF
--- a/tests/Unit/Service/Security/SensioLabsSecurityCheckerTest.php
+++ b/tests/Unit/Service/Security/SensioLabsSecurityCheckerTest.php
@@ -148,7 +148,7 @@ final class SensioLabsSecurityCheckerTest extends TestCase
     private function createAdvisoriesDatabaseRepo(): void
     {
         $this->filesystem->mkdir($this->repoDir);
-        (new Process(['git', 'init'], $this->repoDir))->run();
+        (new Process(['git', 'init', '--initial-branch', 'master'], $this->repoDir))->run();
         $this->filesystem->mirror(
             __DIR__.'/../../../Resources/fixtures/security/security-advisories',
             $this->repoDir


### PR DESCRIPTION
Newer versions of Git set the default branch to 'main', which breaks the tests (as SensioLabsSecurityChecker uses master).

The https://github.com/FriendsOfPHP/security-advisories repo still uses master, so we can't change anything within the actual service yet.