### PR TITLE
Add path style endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -89,7 +89,7 @@ SECURITY_ADVISORIES_DB_DIR=%kernel.project_dir%/var/security-advisories
 # STORAGE_AWS_KEY=example_key # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_SECRET=example_secret # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_ENDPOINT="https://s3.myhost.com" # This is an optional argument, can be used for self-hosted AWS S3 instances
-# STORAGE_AWS_PATH_STYLE_ENDPOINT=true
+# STORAGE_AWS_PATH_STYLE_ENDPOINT=true # Enables Path Style Endpoint setting
 ###< storage ###
 
 ###> excelwebzone/recaptcha-bundle ###

--- a/.env
+++ b/.env
@@ -89,6 +89,7 @@ SECURITY_ADVISORIES_DB_DIR=%kernel.project_dir%/var/security-advisories
 # STORAGE_AWS_KEY=example_key # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_SECRET=example_secret # Only necessary if STORAGE_AWS_OPAQUE_AUTH is true
 # STORAGE_AWS_ENDPOINT="https://s3.myhost.com" # This is an optional argument, can be used for self-hosted AWS S3 instances
+# STORAGE_AWS_PATH_STYLE_ENDPOINT=true
 ###< storage ###
 
 ###> excelwebzone/recaptcha-bundle ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,7 @@ parameters:
     instance_id_file: '%kernel.project_dir%/var/instance-id'
     kernel_version: !php/const Buddy\Repman\Kernel::REPMAN_VERSION
     storage.aws.endpoint: ~ # Default to null
+    storage.aws.pathstyle: ~ # Default to null
     storage.aws.key: ~
     storage.aws.secret: ~
     storage.aws.opaque_auth: false # Default to false
@@ -56,6 +57,7 @@ services:
             - '%env(default:storage.aws.key:STORAGE_AWS_KEY)%'
             - '%env(default:storage.aws.secret:STORAGE_AWS_SECRET)%'
             - '%env(default:storage.aws.endpoint:STORAGE_AWS_ENDPOINT)%'
+            - '%env(default:storage.aws.pathstyle:bool:STORAGE_AWS_PATH_STYLE_ENDPOINT)%'
 
     Aws\S3\S3Client:
         lazy: true

--- a/src/Service/Integration/Aws/S3AdapterFactory.php
+++ b/src/Service/Integration/Aws/S3AdapterFactory.php
@@ -18,16 +18,20 @@ final class S3AdapterFactory
 
     private ?string $endpoint;
 
+    private ?bool $pathStyleEndpoints;
+
     public function __construct(
         string $region,
         bool $isOpaqueAuth,
         ?string $key = null,
         ?string $secret = null,
-        ?string $endpoint = null
+        ?string $endpoint = null,
+        ?bool $pathStyleEndpoints = false
     ) {
         $this->region = $region;
         $this->isOpaqueAuth = $isOpaqueAuth;
         $this->endpoint = $endpoint;
+        $this->pathStyleEndpoints = $pathStyleEndpoints;
 
         if ($this->isOpaqueAuth) {
             if ($key === null || $key === '') {
@@ -47,6 +51,7 @@ final class S3AdapterFactory
         $args = [
             'region' => $this->region,
             'version' => 'latest',
+            'use_path_style_endpoint' => $this->pathStyleEndpoints,
         ];
 
         if ($this->isOpaqueAuth) {

--- a/src/Service/Integration/Aws/S3AdapterFactory.php
+++ b/src/Service/Integration/Aws/S3AdapterFactory.php
@@ -18,7 +18,7 @@ final class S3AdapterFactory
 
     private ?string $endpoint;
 
-    private ?bool $pathStyleEndpoints;
+    private ?bool $pathStyleEndpoint;
 
     public function __construct(
         string $region,
@@ -26,12 +26,12 @@ final class S3AdapterFactory
         ?string $key = null,
         ?string $secret = null,
         ?string $endpoint = null,
-        ?bool $pathStyleEndpoints = false
+        ?bool $pathStyleEndpoint = false
     ) {
         $this->region = $region;
         $this->isOpaqueAuth = $isOpaqueAuth;
         $this->endpoint = $endpoint;
-        $this->pathStyleEndpoints = $pathStyleEndpoints;
+        $this->pathStyleEndpoint = $pathStyleEndpoint;
 
         if ($this->isOpaqueAuth) {
             if ($key === null || $key === '') {
@@ -51,7 +51,7 @@ final class S3AdapterFactory
         $args = [
             'region' => $this->region,
             'version' => 'latest',
-            'use_path_style_endpoint' => $this->pathStyleEndpoints,
+            'use_path_style_endpoint' => $this->pathStyleEndpoint,
         ];
 
         if ($this->isOpaqueAuth) {

--- a/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
+++ b/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
@@ -75,7 +75,7 @@ class S3AdapterFactoryTest extends TestCase
         );
 
         $instance = $factory->create();
-        self::assertSame(true, $instance->getConfig('use_path_style_endpoint'));
+        self::assertTrue($instance->getConfig('use_path_style_endpoint'));
     }
 
     public function testExpectDefaultPathStyleOptionToBeFalse(): void
@@ -89,7 +89,7 @@ class S3AdapterFactoryTest extends TestCase
         );
 
         $instance = $factory->create();
-        self::assertSame(false, $instance->getConfig('use_path_style_endpoint'));
+        self::assertFalse($instance->getConfig('use_path_style_endpoint'));
     }
 
     /**

--- a/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
+++ b/tests/Unit/Service/Integration/Aws/S3AdapterFactoryTest.php
@@ -60,7 +60,36 @@ class S3AdapterFactoryTest extends TestCase
         $instance = $factory->create();
         $endpoint = $instance->getEndpoint();
 
-        self::assertSame($endpoint->getHost(), 's3.example.com');
+        self::assertSame('s3.example.com', $endpoint->getHost());
+    }
+
+    public function testCreateWithPathStyleEndpoints(): void
+    {
+        $factory = new S3AdapterFactory(
+            'eu-east-1',
+            true,
+            'mykey',
+            'secret',
+            'https://s3.example.com',
+            true
+        );
+
+        $instance = $factory->create();
+        self::assertSame(true, $instance->getConfig('use_path_style_endpoint'));
+    }
+
+    public function testExpectDefaultPathStyleOptionToBeFalse(): void
+    {
+        $factory = new S3AdapterFactory(
+            'eu-east-1',
+            true,
+            'mykey',
+            'secret',
+            'https://s3.example.com',
+        );
+
+        $instance = $factory->create();
+        self::assertSame(false, $instance->getConfig('use_path_style_endpoint'));
     }
 
     /**


### PR DESCRIPTION
Some S3 providers only work with “Path Style Endpoints”. Normally, the S3 API requests are sent to `{bucket}.{host}.{tld}`. But with Path Style Endpoints, the API requests are sent to `{host}.{tld}/{bucket}`.

This introduces a new environment variable called `STORAGE_AWS_PATH_STYLE_ENDPOINT` which will evaluate to a boolean value. If this is not set, `null` will be used as a fallback and old/current behaviour is used.

Some background: Up until now we were using a CEPH provided S3 implementation as storage backend. However, due to instabilities of this platform we've decided to start using an OpenStack provided S3 implementation, which requires path styles.