### PR TITLE
Configure PHPStan paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -164,7 +164,7 @@
         ],
         "phpstan": [
             "bin/console cache:clear --env=test",
-            "phpstan analyse src tests --level=max"
+            "phpstan analyse --level=max"
         ],
         "phpunit": [
             "phpunit --colors=always"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,9 @@ parameters:
     level: max
     reportMaybesInPropertyPhpDocTypes: false
     checkExplicitMixed: false
+    paths:
+        - src
+        - tests
     ignoreErrors:
         -
             message: "#^Strict comparison using \\!\\=\\= between string and null will always evaluate to true\\.$#"


### PR DESCRIPTION
This configures the paths to check too in `phpstan.neon`. Makes it easier to just run the command, and for IDEs to auto check your code while developing