### PR TITLE
Create command repman:package:add

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -344,3 +344,12 @@ parameters:
 			count: 1
 			path: tests/Unit/Security/Model/UserTest.php
 
+		-
+			message: "#^Service \"messenger\\.transport\\.async\" is private\\.$#"
+			count: 1
+			path: tests/Functional/Command/AddPackageCommandTest.php
+
+		-
+			message: "#^Service \"Buddy\\\\Repman\\\\Command\\\\AddPackageCommand\" is private\\.$#"
+			count: 3
+			path: tests/Functional/Command/AddPackageCommandTest.php

--- a/src/Command/AddPackageCommand.php
+++ b/src/Command/AddPackageCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Command;
+
+use Buddy\Repman\Entity\Organization;
+use Buddy\Repman\Message\Organization\AddPackage;
+use Buddy\Repman\Message\Organization\SynchronizePackage;
+use Buddy\Repman\Repository\OrganizationRepository;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class AddPackageCommand extends Command
+{
+    protected static $defaultName = 'repman:package:add';
+
+    private MessageBusInterface $bus;
+
+    private OrganizationRepository $organizations;
+
+    public function __construct(MessageBusInterface $bus, OrganizationRepository $organizations)
+    {
+        $this->bus = $bus;
+        $this->organizations = $organizations;
+
+        parent::__construct();
+    }
+
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription('Add an artifact package to an organization')
+            ->addArgument('organization', InputArgument::REQUIRED, 'Organization alias')
+            ->addArgument('type', InputArgument::REQUIRED, 'Type of the project. Just artifact available for now.')
+            ->addArgument('url', InputArgument::REQUIRED, 'Artifact path')
+            ->addOption('keep-last-releases', 'k', InputOption::VALUE_OPTIONAL, 'Artifact path', '0')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($input->getArgument('type') !== 'artifact') {
+            $io->error('Just artifact available for now.');
+
+            return 1;
+        }
+
+        try {
+            $organization = $this->getOrganizationFromAlias($input->getArgument('organization'));
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return 1;
+        }
+
+        $this->bus->dispatch(new AddPackage(
+            $id = Uuid::uuid4()->toString(),
+            $organization->id()->toString(),
+            $input->getArgument('url'),
+            'artifact',
+            [],
+            intval($input->getOption('keep-last-releases'))
+        ));
+        $this->bus->dispatch(new SynchronizePackage($id));
+
+        $output->writeln('Package has been added and will be synchronized in the background');
+
+        return 0;
+    }
+
+    protected function getOrganizationFromAlias(string $organizationAlias): Organization
+    {
+        $organization = $this->organizations->findOneBy(['alias' => $organizationAlias]);
+
+        if (!$organization instanceof Organization) {
+            throw new \InvalidArgumentException(sprintf('Organization with alias %s not found.', $organizationAlias));
+        }
+
+        return $organization;
+    }
+}

--- a/tests/Functional/Command/AddPackageCommandTest.php
+++ b/tests/Functional/Command/AddPackageCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buddy\Repman\Tests\Functional\Command;
+
+use Buddy\Repman\Command\AddPackageCommand;
+use Buddy\Repman\Message\Security\ScanPackage;
+use Buddy\Repman\Tests\Functional\FunctionalTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemoryTransport;
+
+final class AddPackageCommandTest extends FunctionalTestCase
+{
+    private string $userId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userId = $this->createAndLoginAdmin();
+        $this->fixtures->createOrganization('buddy', $this->userId);
+    }
+
+    public function testAddSuccess(): void
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = $this->container()->get('messenger.transport.async');
+        $transport->reset();
+
+        $commandTester = new CommandTester($this->container()->get(AddPackageCommand::class));
+        $result = $commandTester->execute([
+            'organization' => 'buddy',
+            'type' => 'artifact',
+            'url' => '/path/to/package',
+        ]);
+
+        self::assertEquals($result, 0);
+        self::assertCount(1, $transport->getSent());
+        self::assertInstanceOf(ScanPackage::class, $transport->getSent()[0]->getMessage());
+    }
+
+    public function testInvalidOrganization(): void
+    {
+        $commandTester = new CommandTester($this->container()->get(AddPackageCommand::class));
+        $result = $commandTester->execute([
+            'organization' => 'vendor',
+            'type' => 'artifact',
+            'url' => '/path/to/package',
+        ]);
+
+        self::assertEquals($result, 1);
+    }
+
+    public function testInvalidType(): void
+    {
+        $commandTester = new CommandTester($this->container()->get(AddPackageCommand::class));
+        $result = $commandTester->execute([
+            'organization' => 'vendor',
+            'type' => 'vcs',
+            'url' => '/path/to/package',
+        ]);
+
+        self::assertEquals($result, 1);
+    }
+}


### PR DESCRIPTION
This command allow to reproduce the add package user interface.

The idea of the command comes from a need of an automation of release new packages available in a directory.

For now the command supports just artifacts type. It can evolve to all packages types. The package management can be a service and used by controller and command.