### PR TITLE
Adjusted proxy handling for Repman instance: Added explicit proxy con…

### DIFF
--- a/src/Service/Downloader/ReactDownloader.php
+++ b/src/Service/Downloader/ReactDownloader.php
@@ -90,13 +90,24 @@ final class ReactDownloader implements Downloader
      */
     private function createContext(array $headers = [])
     {
+        $proxy = getenv('HTTP_PROXY') ?: null;
+        $proxyContext = [];
+
+        if ($proxy) {
+            $proxyContext = [
+                'proxy' => $proxy,
+                'request_fulluri' => true,
+            ];
+        }
+
         return stream_context_create([
-            'http' => [
-                'header' => array_merge([sprintf('User-Agent: %s', $this->userAgent())], $headers),
-                'follow_location' => 1,
-                'max_redirects' => 20,
-            ],
-        ]);
+             'http' => array_merge([
+                 'header' => array_merge([sprintf('User-Agent: %s', $this->userAgent())], $headers),
+                 'follow_location' => 1,
+                 'max_redirects' => 20,
+             ], $proxyContext),
+            'https' => $proxyContext,
+             ]);
     }
 
     private function userAgent(): string


### PR DESCRIPTION
…figuration via stream context to ensure functionality behind a corporate proxy.

Since my Repman instance is running behind a corporate proxy, I couldn't use the native proxy functionality provided by Repman directly, as it didn't work in my setup. However, by explicitly setting the proxy configuration in the stream context of my HTTP requests, the connection works as expected. This approach ensures that the traffic is routed through the proxy without relying on Repman's internal handling.